### PR TITLE
fix: add platform-specific bundle targets for Linux/macOS

### DIFF
--- a/src-tauri/tauri.linux.conf.json
+++ b/src-tauri/tauri.linux.conf.json
@@ -1,0 +1,5 @@
+{
+  "bundle": {
+    "targets": ["deb", "appimage"]
+  }
+}

--- a/src-tauri/tauri.macos.conf.json
+++ b/src-tauri/tauri.macos.conf.json
@@ -1,0 +1,5 @@
+{
+  "bundle": {
+    "targets": ["dmg"]
+  }
+}


### PR DESCRIPTION
## Summary
- `targets: ["nsis"]` in tauri.conf.json is Windows-only
- Linux/macOS builds compiled but produced no installable artifacts
- Added `tauri.linux.conf.json` (deb + appimage) and `tauri.macos.conf.json` (dmg)
- Tauri v2 auto-merges platform configs via JSON Merge Patch