### PR TITLE
feat: Sprint 3 completion — screenshots, Docker auto-seed, README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,12 @@ docker compose up -d
 
 Open `http://localhost:3000` in your browser. Data persists in a Docker volume.
 
+To run with demo data pre-loaded:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.demo.yml up -d
+```
+
 ### From Source
 
 Requires [Node.js](https://nodejs.org/) 20+.

--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -1,0 +1,5 @@
+services:
+  skima:
+    container_name: skima-demo
+    environment:
+      - DEMO_MODE=true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,9 @@
 services:
   skima:
     build: .
-    container_name: skima-demo
+    container_name: skima
     ports:
       - "3000:3001"
-    environment:
-      - DEMO_MODE=true
     volumes:
       - skima-data:/app/data
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- Retake all screenshots in English (dashboard, matrix, evolution, roles, setup)
- Add Role Profiles screenshot to landing page and README
- Docker entrypoint auto-seeds demo data when `DEMO_MODE=true`
- Separate `docker-compose.yml` (normal) and `docker-compose.demo.yml` (demo override)
- Fix dashboard spacing and chart responsive height
- Translate remaining strings (DashboardHeader, seed data, demo route, auth route)
- Update test counts in README (778 tests)
- Fix demo-middleware test for unblocked seed-demo endpoint

## Test plan
- [ ] `npm test` — 778 tests passing (696 client + 82 server)
- [ ] `docker compose up -d` → shows setup wizard (no demo data)
- [ ] `docker compose -f docker-compose.yml -f docker-compose.demo.yml up -d` → seeds demo data, shows landing
- [ ] All 5 README screenshots render correctly on GitHub
- [ ] Landing page shows Role Profiles screenshot