### PR TITLE
feat: online demo UX — download CTAs, Docker split, tab title

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -16,7 +16,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&display=swap" rel="stylesheet">
-    <title>Skima — Free Team Skills Management | Desktop App</title>
+    <title>Skima</title>
     <meta name="description" content="Free, source-available desktop app for team skills management. Map skills, spot gaps, track growth. Your data never leaves your machine.">
 
     <!-- Open Graph / Social -->

--- a/client/src/components/common/DemoBanner.jsx
+++ b/client/src/components/common/DemoBanner.jsx
@@ -1,16 +1,19 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { FlaskConical, X, Settings } from 'lucide-react';
+import { FlaskConical, X, Settings, Download } from 'lucide-react';
 import { useConfig } from '../../contexts/ConfigContext';
+
+const GITHUB_RELEASES = 'https://github.com/henfrydls/Skima/releases';
 
 /**
  * DemoBanner - Persistent banner shown when app is in demo mode.
  *
  * Shows at the top of the main content area. Can be dismissed
  * for the session via sessionStorage so it won't reappear on navigation.
+ * When isOnlineDemo, shows "Download App" instead of "Set Up My Space".
  */
 export default function DemoBanner() {
-  const { isDemo } = useConfig();
+  const { isDemo, isOnlineDemo } = useConfig();
   const navigate = useNavigate();
   const [dismissed, setDismissed] = useState(() => {
     try { return sessionStorage.getItem('demoBannerDismissed') === 'true'; }
@@ -31,14 +34,27 @@ export default function DemoBanner() {
       <span className="text-amber-800 flex-1">
         <span className="font-medium">Demo Mode</span> — You're exploring with sample data.
       </span>
-      <button
-        onClick={() => navigate('/setup')}
-        className="flex items-center gap-1.5 px-3 py-1 text-xs font-medium text-primary
-                 bg-white border border-primary/20 rounded-lg hover:bg-primary/5 transition-colors"
-      >
-        <Settings size={12} />
-        Set Up My Space
-      </button>
+      {isOnlineDemo ? (
+        <a
+          href={GITHUB_RELEASES}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex items-center gap-1.5 px-3 py-1 text-xs font-medium text-primary
+                   bg-white border border-primary/20 rounded-lg hover:bg-primary/5 transition-colors"
+        >
+          <Download size={12} />
+          Download App
+        </a>
+      ) : (
+        <button
+          onClick={() => navigate('/setup')}
+          className="flex items-center gap-1.5 px-3 py-1 text-xs font-medium text-primary
+                   bg-white border border-primary/20 rounded-lg hover:bg-primary/5 transition-colors"
+        >
+          <Settings size={12} />
+          Set Up My Space
+        </button>
+      )}
       <button
         onClick={handleDismiss}
         className="p-1 text-amber-400 hover:text-amber-600 transition-colors"

--- a/client/src/components/layout/Layout.jsx
+++ b/client/src/components/layout/Layout.jsx
@@ -11,10 +11,13 @@ import {
   LogIn,
   LogOut,
   User,
-  FlaskConical
+  FlaskConical,
+  Download
 } from 'lucide-react';
 import { useAuth } from '../../contexts/AuthContext';
 import { useConfig } from '../../contexts/ConfigContext';
+
+const GITHUB_RELEASES = 'https://github.com/henfrydls/Skima/releases';
 import { useAppVersion } from '../../hooks/useAppVersion';
 import LoginModal from '../auth/LoginModal';
 import SidebarUser from './SidebarUser';
@@ -78,7 +81,7 @@ export default function Layout() {
   const [isCollapsed, setIsCollapsed] = useState(false);
   const [showLoginModal, setShowLoginModal] = useState(false);
   const { isAuthenticated, login } = useAuth();
-  const { adminName, isDemo } = useConfig();
+  const { adminName, isDemo, isOnlineDemo } = useConfig();
   const version = useAppVersion();
   
   const navItems = getNavItems(isAuthenticated);
@@ -103,15 +106,31 @@ export default function Layout() {
       >
         {/* Header del Sidebar - Skima Logo */}
         <div className="flex items-center justify-between h-16 px-3 border-b border-gray-100 relative">
-          {/* Logo with fade transition - stays in place */}
-          <img
-            src={logoFull}
-            alt="Skima"
-            className={`
-              h-8 transition-[max-width,opacity] duration-200 ease-out overflow-hidden
-              ${isCollapsed ? 'opacity-0 pointer-events-none max-w-0' : 'opacity-100 max-w-[150px] delay-75'}
-            `}
-          />
+          {/* Logo with fade transition - clickable to landing in online demo */}
+          {isOnlineDemo ? (
+            <button
+              onClick={() => {
+                document.cookie = 'demo_active=; max-age=0; path=/';
+                navigate('/');
+              }}
+              className={`
+                h-8 transition-[max-width,opacity] duration-200 ease-out overflow-hidden cursor-pointer
+                ${isCollapsed ? 'opacity-0 pointer-events-none max-w-0' : 'opacity-100 max-w-[150px] delay-75'}
+              `}
+              title="Back to Landing"
+            >
+              <img src={logoFull} alt="Skima" className="h-8" />
+            </button>
+          ) : (
+            <img
+              src={logoFull}
+              alt="Skima"
+              className={`
+                h-8 transition-[max-width,opacity] duration-200 ease-out overflow-hidden
+                ${isCollapsed ? 'opacity-0 pointer-events-none max-w-0' : 'opacity-100 max-w-[150px] delay-75'}
+              `}
+            />
+          )}
           {/* Collapse/Expand button */}
           <button
             onClick={() => setIsCollapsed(!isCollapsed)}
@@ -175,25 +194,49 @@ export default function Layout() {
                 Demo Mode
               </span>
             </button>
-            <button
-              onClick={() => navigate('/setup')}
-              className={`
-                w-full flex items-center py-2 mt-1 rounded-lg bg-primary/10 text-primary hover:bg-primary/20
-                transition-[padding] duration-[250ms] ease-out text-xs font-medium overflow-hidden
-                ${isCollapsed ? 'px-[14px]' : 'px-3'}
-              `}
-              title={isCollapsed ? 'Set Up My Space' : undefined}
-            >
-              <Settings size={16} className="flex-shrink-0" />
-              <span
+            {isOnlineDemo ? (
+              <a
+                href={GITHUB_RELEASES}
+                target="_blank"
+                rel="noopener noreferrer"
                 className={`
-                  whitespace-nowrap overflow-hidden transition-[max-width,opacity,margin] duration-200 ease-out
-                  ${isCollapsed ? 'max-w-0 opacity-0 ml-0' : 'max-w-[180px] opacity-100 ml-2 delay-75'}
+                  w-full flex items-center py-2 mt-1 rounded-lg bg-primary/10 text-primary hover:bg-primary/20
+                  transition-[padding] duration-[250ms] ease-out text-xs font-medium overflow-hidden
+                  ${isCollapsed ? 'px-[14px]' : 'px-3'}
                 `}
+                title={isCollapsed ? 'Download App' : undefined}
               >
-                Set Up My Space
-              </span>
-            </button>
+                <Download size={16} className="flex-shrink-0" />
+                <span
+                  className={`
+                    whitespace-nowrap overflow-hidden transition-[max-width,opacity,margin] duration-200 ease-out
+                    ${isCollapsed ? 'max-w-0 opacity-0 ml-0' : 'max-w-[180px] opacity-100 ml-2 delay-75'}
+                  `}
+                >
+                  Download App
+                </span>
+              </a>
+            ) : (
+              <button
+                onClick={() => navigate('/setup')}
+                className={`
+                  w-full flex items-center py-2 mt-1 rounded-lg bg-primary/10 text-primary hover:bg-primary/20
+                  transition-[padding] duration-[250ms] ease-out text-xs font-medium overflow-hidden
+                  ${isCollapsed ? 'px-[14px]' : 'px-3'}
+                `}
+                title={isCollapsed ? 'Set Up My Space' : undefined}
+              >
+                <Settings size={16} className="flex-shrink-0" />
+                <span
+                  className={`
+                    whitespace-nowrap overflow-hidden transition-[max-width,opacity,margin] duration-200 ease-out
+                    ${isCollapsed ? 'max-w-0 opacity-0 ml-0' : 'max-w-[180px] opacity-100 ml-2 delay-75'}
+                  `}
+                >
+                  Set Up My Space
+                </span>
+              </button>
+            )}
           </div>
         )}
 

--- a/client/src/pages/DashboardView.jsx
+++ b/client/src/pages/DashboardView.jsx
@@ -1,7 +1,9 @@
 import { useState, useEffect, useMemo, useRef } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
-import { ArrowRight, Lightbulb, Settings, FlaskConical } from 'lucide-react';
+import { ArrowRight, Lightbulb, Settings, FlaskConical, Download } from 'lucide-react';
 import { useConfig } from '../contexts/ConfigContext';
+
+const GITHUB_RELEASES = 'https://github.com/henfrydls/Skima/releases';
 import { API_BASE } from '../lib/apiBase';
 import { preloadData } from '../lib/dataPreload';
 import {
@@ -28,7 +30,7 @@ const isCriticalGap = (skillData) => {
 // DASHBOARD VIEW - Executive Summary (Redesigned)
 // ============================================
 export default function DashboardView() {
-  const { isDemo } = useConfig();
+  const { isDemo, isOnlineDemo } = useConfig();
   const navigate = useNavigate();
 
   // Data state
@@ -219,23 +221,41 @@ export default function DashboardView() {
         />
       </div>
 
-      {/* Demo mode: Setup prompt card */}
+      {/* Demo mode: Setup prompt or Download card */}
       {isDemo && (
         <div className="flex items-center gap-4 p-4 bg-white border border-amber-200 rounded-xl shadow-sm">
           <div className="w-10 h-10 rounded-lg bg-amber-50 flex items-center justify-center flex-shrink-0">
             <FlaskConical size={20} className="text-amber-600" />
           </div>
           <div className="flex-1 min-w-0">
-            <p className="text-sm font-medium text-gray-800">You're exploring with sample data</p>
-            <p className="text-xs text-gray-500">When you're ready, set up your space with your own data.</p>
+            <p className="text-sm font-medium text-gray-800">
+              {isOnlineDemo ? 'Like what you see?' : "You're exploring with sample data"}
+            </p>
+            <p className="text-xs text-gray-500">
+              {isOnlineDemo
+                ? 'Download Skima to manage your own team — free, offline, private.'
+                : 'When you\'re ready, set up your space with your own data.'}
+            </p>
           </div>
-          <button
-            onClick={() => navigate('/setup')}
-            className="flex items-center gap-1.5 px-4 py-2 text-sm font-medium text-primary bg-primary/5 border border-primary/20 rounded-lg hover:bg-primary/10 transition-colors flex-shrink-0"
-          >
-            <Settings size={14} />
-            Set Up My Space
-          </button>
+          {isOnlineDemo ? (
+            <a
+              href={GITHUB_RELEASES}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-1.5 px-4 py-2 text-sm font-medium text-primary bg-primary/5 border border-primary/20 rounded-lg hover:bg-primary/10 transition-colors flex-shrink-0"
+            >
+              <Download size={14} />
+              Download App
+            </a>
+          ) : (
+            <button
+              onClick={() => navigate('/setup')}
+              className="flex items-center gap-1.5 px-4 py-2 text-sm font-medium text-primary bg-primary/5 border border-primary/20 rounded-lg hover:bg-primary/10 transition-colors flex-shrink-0"
+            >
+              <Settings size={14} />
+              Set Up My Space
+            </button>
+          )}
         </div>
       )}
 


### PR DESCRIPTION
## Summary
- Add "Download App" CTAs throughout the online demo (banner, sidebar, dashboard card) linking to GitHub Releases
- Make sidebar logo clickable to return to landing page (clears demo cookie)
- Separate `docker-compose.yml` (normal) and `docker-compose.demo.yml` (demo override)
- Docker entrypoint auto-seeds demo data when `DEMO_MODE=true` and resets DB when switching to normal mode
- Change browser tab title to "Skima"
- All demo CTAs conditional on `isOnlineDemo` — local desktop experience unchanged

## Test plan
- [ ] `npm run test:client` — 696 tests passing
- [ ] Online demo: banner shows "Download App" → opens GitHub Releases
- [ ] Online demo: sidebar shows "Download App" instead of "Set Up My Space"
- [ ] Online demo: clicking sidebar logo clears cookie and returns to landing
- [ ] Online demo: dashboard card shows "Like what you see? Download Skima..."
- [ ] Local demo: "Set Up My Space" buttons unchanged
- [ ] `docker compose up -d` → clean setup wizard (no DEMO_MODE)
- [ ] `docker compose -f docker-compose.yml -f docker-compose.demo.yml up -d` → demo with auto-seed