### PR TITLE
chore: release v1.1.0

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "skima",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.1.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skima",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": true,
   "description": "Skima - Skills Management App",
   "scripts": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skima-server",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": true,
   "type": "module",
   "bin": "src/index.js",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Skima",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "identifier": "com.dlslabs.skima",
   "build": {
     "beforeDevCommand": "npm run dev:client",


### PR DESCRIPTION
## Release v1.1.0

### What's New
- **Landing Page** — Hero, features showcase, screenshots, download links at skima.henfrydls.com
- **Online Demo Mode** — Try Skima in the browser with sample data, destructive operations blocked
- **English UI** — All 200+ strings translated from Spanish to English
- **Docker Auto-seed** — Entrypoint auto-seeds demo data when `DEMO_MODE=true`
- **Download CTAs** — "Download App" links in banner, sidebar, and dashboard when in online demo
- **Back to Site** — Sidebar nav item to return from demo to landing page
- **Role Profiles Screenshot** — New screenshot added to README and landing page
- **Separate Docker Compose** — `docker-compose.yml` (normal) + `docker-compose.demo.yml` (demo override)

### Bug Fixes
- Fix seed-demo endpoint blocked in demo mode
- Fix Prisma transaction timeout for large seed operations
- Fix dashboard spacing below "Explore Team Matrix"
- Responsive chart height with `clamp()`
- Show up to 5 risks in Top Risks panel

### Stats
- 778 tests passing (696 client + 82 server)
- 75 files changed across 11 PRs (#6-#11)