### PR TITLE
feat: add Umami analytics tracking

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -12,6 +12,9 @@
     <meta name="msapplication-TileColor" content="#2d676e">
     <meta name="theme-color" content="#2d676e">
 
+    <!-- Analytics (Umami — privacy-first, no cookies) -->
+    <script defer src="https://analytics.henfrydls.com/stats.js" data-website-id="e1a101bc-4436-46f9-8859-ec19dba3c043"></script>
+
     <!-- Google Fonts: Inter -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
## Summary
- Add Umami analytics script to index.html (privacy-first, no cookies)
- Self-hosted at analytics.henfrydls.com
- Tracks pageviews and landing-to-demo conversion flow
- Script renamed to stats.js to reduce adblocker interference

## Test plan
- [ ] Visit skima.henfrydls.com and verify pageview appears in Umami dashboard
- [ ] Navigate landing → demo → dashboard and verify all pageviews tracked