### PR TITLE
feat: runtime analytics injection for online demo

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -12,9 +12,6 @@
     <meta name="msapplication-TileColor" content="#2d676e">
     <meta name="theme-color" content="#2d676e">
 
-    <!-- Analytics (Umami — privacy-first, no cookies) -->
-    <script defer src="https://analytics.henfrydls.com/stats.js" data-website-id="e1a101bc-4436-46f9-8859-ec19dba3c043"></script>
-
     <!-- Google Fonts: Inter -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -1,5 +1,9 @@
+# Online demo override — use with: docker compose -f docker-compose.yml -f docker-compose.demo.yml up -d
+# Seeds sample data on first run, injects privacy-first analytics (Umami),
+# and blocks destructive operations. See docker/entrypoint.sh for details.
 services:
   skima:
     container_name: skima-demo
     environment:
       - DEMO_MODE=true
+      - UMAMI_WEBSITE_ID=e1a101bc-4436-46f9-8859-ec19dba3c043

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -19,6 +19,24 @@ for i in $(seq 1 30); do
   sleep 1
 done
 
+# Analytics injection (runtime only, never in source code)
+#
+# When running as an online demo, we inject a self-hosted Umami analytics
+# script into the built HTML at container startup. This keeps the tracking
+# code out of the repository — desktop and local Docker users never see it.
+#
+# Required env vars (set in docker-compose.demo.yml):
+#   UMAMI_WEBSITE_ID  — UUID from Umami dashboard (e.g. "e1a101bc-...")
+#   UMAMI_HOST        — Optional, defaults to https://analytics.henfrydls.com
+#
+# The script is privacy-first: no cookies, no cross-site tracking,
+# respects Do Not Track. Used to measure landing-to-demo conversion.
+if [ "$DEMO_MODE" = "true" ] && [ -n "$UMAMI_WEBSITE_ID" ]; then
+  UMAMI_HOST="${UMAMI_HOST:-https://analytics.henfrydls.com}"
+  sed -i "s|</head>|<script defer src=\"${UMAMI_HOST}/stats.js\" data-website-id=\"${UMAMI_WEBSITE_ID}\"></script></head>|" /app/client/dist/index.html
+  echo "  Analytics script injected."
+fi
+
 # Handle DB state based on DEMO_MODE
 if [ "$DEMO_MODE" = "true" ]; then
   IS_SETUP=$(wget -q -O - http://localhost:3001/api/config 2>/dev/null | grep -o '"isSetup":true')


### PR DESCRIPTION
## Summary
- Remove Umami script tag from source code (index.html)
- Docker entrypoint injects analytics at container startup when `DEMO_MODE=true` and `UMAMI_WEBSITE_ID` is set
- Desktop and local Docker users never see analytics code
- Privacy-first: no cookies, no cross-site tracking, respects DNT

## How it works
The entrypoint uses `sed` to inject the script into the built HTML at runtime.
Configured via environment variables in `docker-compose.demo.yml`:
- `UMAMI_WEBSITE_ID` — UUID from Umami dashboard
- `UMAMI_HOST` — Optional, defaults to `https://analytics.henfrydls.com`

## Test plan
- [ ] `docker compose up -d` (normal) → no analytics script in page source
- [ ] `docker compose -f docker-compose.yml -f docker-compose.demo.yml up -d` → analytics script injected
- [ ] Visit skima.henfrydls.com → pageview appears in Umami dashboard
- [ ] Local dev (`npm run dev`) → no analytics script