### PR TITLE
chore: bump version to 1.3.3 for Sprint 7.6 release

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "skima",
   "private": true,
-  "version": "1.3.2",
+  "version": "1.3.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skima",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "private": true,
   "description": "Skima - People Development Platform",
   "scripts": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skima-server",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "private": true,
   "type": "module",
   "bin": "src/index.js",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2971,7 +2971,7 @@ checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "skima"
-version = "1.0.0"
+version = "1.3.3"
 dependencies = [
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skima"
-version = "1.3.2"
+version = "1.3.3"
 description = "Skima - People Development Platform"
 authors = ["DLSLabs"]
 edition = "2024"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Skima",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "identifier": "com.dlslabs.skima",
   "build": {
     "beforeDevCommand": "npm run dev:client",


### PR DESCRIPTION
## Summary
- Version bump to 1.3.3 across all package files (package.json x3, tauri.conf.json, Cargo.toml, Cargo.lock)
- Includes PR #27 changes: README update, landing page Development Plans card, 5 demo seed plans

## Changes in v1.3.3 (since v1.3.2)
- Updated README with ghcr.io Docker instructions and Development Plans screenshot
- Landing page now shows Development Plans feature card with screenshot
- Demo seed expanded to 5 plans (2 active, 1 completed, 1 draft, 1 cancelled)
- Fixed Development Plans screenshot path in landing page

## Test plan
- [x] `npm run build` succeeds
- [x] Version shows 1.3.3 in all files
- [x] Merge triggers Release + Docker workflows