### PR TITLE
chore: release v1.3.4

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "skima",
   "private": true,
-  "version": "1.3.3",
+  "version": "1.3.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skima",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "private": true,
   "description": "Skima - People Development Platform",
   "scripts": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skima-server",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "private": true,
   "type": "module",
   "bin": "src/index.js",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2971,7 +2971,7 @@ checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "skima"
-version = "1.3.3"
+version = "1.3.4"
 dependencies = [
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skima"
-version = "1.3.3"
+version = "1.3.4"
 description = "Skima - People Development Platform"
 authors = ["DLSLabs"]
 edition = "2024"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Skima",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "identifier": "com.dlslabs.skima",
   "build": {
     "beforeDevCommand": "npm run dev:client",


### PR DESCRIPTION
## Summary
- Version bump to 1.3.4 across all package files

## Changes in v1.3.4 (since v1.3.3)
- **Fix:** Prisma binary targets for desktop Linux (debian-openssl-3.0.x)
- **Fix:** Development tab sort order (Active, Completed, Draft, Cancelled)
- **Feat:** Search filter in Development tab
- **Feat:** Edit/delete restrictions by plan status with Lock icon
- **Test:** 40 new DevelopmentTab tests (811 total client tests)
- **Chore:** Coverage thresholds adjusted to 70/65/60/65

## Test plan
- [x] CI passes on Ubuntu, macOS, Windows
- [x] Desktop .deb: "Explore with demo data" works
- [x] Merge triggers Release + Docker workflows