### PR TITLE
v1.3.5 — Development Plans + Evolution bugfixes

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "skima",
   "private": true,
-  "version": "1.3.4",
+  "version": "1.3.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/client/src/components/common/Select.jsx
+++ b/client/src/components/common/Select.jsx
@@ -1,0 +1,149 @@
+import { useState, useEffect, useRef } from 'react';
+import { createPortal } from 'react-dom';
+import { ChevronDown } from 'lucide-react';
+
+/**
+ * Select - Reusable custom dropdown matching CollaboratorSelect / SkillSelect styling.
+ * Renders the options panel via a portal with fixed positioning so it escapes
+ * parent containers with overflow:hidden (e.g. modal dialogs).
+ *
+ * Props:
+ * - options: Array<{ value: string|number, label: string }>
+ * - value: current value
+ * - onChange: (value) => void
+ * - placeholder: string shown when no value selected
+ * - id, name: passed through for form association / labels
+ * - className: extra classes for the trigger button
+ */
+export default function Select({
+  options = [],
+  value,
+  onChange,
+  placeholder = 'Select...',
+  id,
+  name,
+  className = '',
+}) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [dropdownStyle, setDropdownStyle] = useState({});
+  const triggerRef = useRef(null);
+  const panelRef = useRef(null);
+
+  const selected = options.find(o => o.value === value);
+
+  const updatePosition = () => {
+    if (!triggerRef.current) return;
+    const rect = triggerRef.current.getBoundingClientRect();
+    const spaceBelow = window.innerHeight - rect.bottom;
+    const spaceAbove = rect.top;
+    const maxH = Math.min(Math.max(spaceBelow, spaceAbove) - 20, 320);
+    const openUp = spaceAbove > spaceBelow;
+
+    setDropdownStyle({
+      position: 'fixed',
+      left: rect.left,
+      width: rect.width,
+      maxHeight: maxH,
+      ...(openUp
+        ? { bottom: window.innerHeight - rect.top + 4 }
+        : { top: rect.bottom + 4 }
+      ),
+    });
+  };
+
+  useEffect(() => {
+    if (!isOpen) return;
+    updatePosition();
+    const handle = () => updatePosition();
+    window.addEventListener('scroll', handle, true);
+    window.addEventListener('resize', handle);
+    return () => {
+      window.removeEventListener('scroll', handle, true);
+      window.removeEventListener('resize', handle);
+    };
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleClick = (e) => {
+      if (
+        triggerRef.current && !triggerRef.current.contains(e.target) &&
+        panelRef.current && !panelRef.current.contains(e.target)
+      ) {
+        setIsOpen(false);
+      }
+    };
+    const handleKey = (e) => { if (e.key === 'Escape') setIsOpen(false); };
+    document.addEventListener('mousedown', handleClick);
+    document.addEventListener('keydown', handleKey);
+    return () => {
+      document.removeEventListener('mousedown', handleClick);
+      document.removeEventListener('keydown', handleKey);
+    };
+  }, [isOpen]);
+
+  const handleSelect = (optValue) => {
+    onChange(optValue);
+    setIsOpen(false);
+  };
+
+  return (
+    <div className="relative w-full">
+      <button
+        ref={triggerRef}
+        id={id}
+        name={name}
+        type="button"
+        onClick={() => setIsOpen(!isOpen)}
+        aria-haspopup="listbox"
+        aria-expanded={isOpen}
+        className={`
+          w-full flex items-center gap-2 pl-3 pr-3 py-2 rounded-lg border bg-white text-sm text-left
+          transition-all duration-150
+          ${isOpen
+            ? 'border-primary ring-2 ring-primary/20'
+            : 'border-gray-200 hover:border-gray-300'
+          }
+          ${className}
+        `}
+      >
+        <span className={`flex-1 truncate ${selected ? 'text-gray-800' : 'text-gray-400'}`}>
+          {selected ? selected.label : placeholder}
+        </span>
+        <ChevronDown
+          size={14}
+          className={`text-gray-400 flex-shrink-0 transition-transform duration-200 ${isOpen ? 'rotate-180' : ''}`}
+        />
+      </button>
+
+      {isOpen && createPortal(
+        <div
+          ref={panelRef}
+          style={dropdownStyle}
+          role="listbox"
+          className="bg-white rounded-lg border border-gray-200 shadow-lg z-[9999] overflow-y-auto"
+        >
+          {options.map(opt => (
+            <button
+              key={opt.value}
+              type="button"
+              role="option"
+              aria-selected={opt.value === value}
+              onClick={() => handleSelect(opt.value)}
+              className={`
+                w-full text-left px-3 py-2 text-sm transition-colors
+                ${opt.value === value
+                  ? 'bg-primary/5 text-primary font-medium'
+                  : 'text-gray-700 hover:bg-gray-50'
+                }
+              `}
+            >
+              {opt.label}
+            </button>
+          ))}
+        </div>,
+        document.body
+      )}
+    </div>
+  );
+}

--- a/client/src/components/common/Select.jsx
+++ b/client/src/components/common/Select.jsx
@@ -36,8 +36,14 @@ export default function Select({
     const rect = triggerRef.current.getBoundingClientRect();
     const spaceBelow = window.innerHeight - rect.bottom;
     const spaceAbove = rect.top;
-    const maxH = Math.min(Math.max(spaceBelow, spaceAbove) - 20, 320);
-    const openUp = spaceAbove > spaceBelow;
+    // Prefer opening downward (predictable). Only flip up when the panel
+    // would not fit below AND there's strictly more room above.
+    const PREFERRED_HEIGHT = 320;
+    const MARGIN = 20;
+    const fitsBelow = spaceBelow >= Math.min(PREFERRED_HEIGHT, spaceBelow) + MARGIN
+      || spaceBelow >= 200; // Always prefer below if we have at least ~200px
+    const openUp = !fitsBelow && spaceAbove > spaceBelow;
+    const maxH = Math.min(openUp ? spaceAbove - MARGIN : spaceBelow - MARGIN, PREFERRED_HEIGHT);
 
     setDropdownStyle({
       position: 'fixed',

--- a/client/src/components/common/index.js
+++ b/client/src/components/common/index.js
@@ -14,3 +14,4 @@ export {
   DevelopmentSettingsSkeleton
 } from './LoadingSkeleton';
 export { EmptyState } from './EmptyState';
+export { default as Select } from './Select';

--- a/client/src/components/development/ActionRow.jsx
+++ b/client/src/components/development/ActionRow.jsx
@@ -21,7 +21,7 @@ export default function ActionRow({ action, onUpdate, onDelete, readOnly = false
   const [toggling, setToggling] = useState(false);
 
   const isCompleted = action.status === 'completed';
-  const typeConfig = ACTION_TYPES[action.type] || ACTION_TYPES.experience;
+  const typeConfig = ACTION_TYPES[action.actionType] || ACTION_TYPES.experience;
   const TypeIcon = typeConfig.icon;
 
   const handleToggle = async () => {

--- a/client/src/components/development/__tests__/ActionRow.test.jsx
+++ b/client/src/components/development/__tests__/ActionRow.test.jsx
@@ -22,7 +22,7 @@ vi.mock('react-hot-toast', () => ({
 const mockAction = {
   id: 1,
   title: 'Complete testing course',
-  type: 'formal',
+  actionType: 'formal',
   status: 'completed',
   dueDate: '2026-05-01',
   completedAt: '2026-04-15T00:00:00Z',
@@ -51,21 +51,36 @@ describe('ActionRow', () => {
   });
 
   it('shows correct type badge for experience (blue)', () => {
-    renderAction({ action: { ...mockAction, type: 'experience' } });
+    renderAction({ action: { ...mockAction, actionType: 'experience' } });
     const badge = screen.getByText('Experience');
     expect(badge.closest('span')).toHaveClass('bg-blue-50', 'text-blue-700');
   });
 
   it('shows correct type badge for social (purple)', () => {
-    renderAction({ action: { ...mockAction, type: 'social' } });
+    renderAction({ action: { ...mockAction, actionType: 'social' } });
     const badge = screen.getByText('Social');
     expect(badge.closest('span')).toHaveClass('bg-purple-50', 'text-purple-700');
   });
 
   it('shows correct type badge for self_directed (amber)', () => {
-    renderAction({ action: { ...mockAction, type: 'self_directed' } });
+    renderAction({ action: { ...mockAction, actionType: 'self_directed' } });
     const badge = screen.getByText('Self-directed');
     expect(badge.closest('span')).toHaveClass('bg-amber-50', 'text-amber-700');
+  });
+
+  // Bug #33: API returns `actionType`, component must read that field (not `type`)
+  it('reads actionType from real API shape (not legacy "type")', () => {
+    const apiAction = {
+      id: 99,
+      title: 'Real API shape action',
+      actionType: 'formal',
+      status: 'not_started',
+      dueDate: null,
+      completedAt: null,
+    };
+    renderAction({ action: apiAction });
+    const badge = screen.getByText('Formal');
+    expect(badge.closest('span')).toHaveClass('bg-green-50', 'text-green-700');
   });
 
   it('shows due date when provided', () => {

--- a/client/src/components/evolution/EvolutionList.jsx
+++ b/client/src/components/evolution/EvolutionList.jsx
@@ -1,4 +1,5 @@
 import { LineChart, Line, ResponsiveContainer, Tooltip } from 'recharts';
+import { formatDateOnlyMonthYear } from '../../lib/timeLogic';
 
 /**
  * EvolutionList - Detailed Collaborator Table
@@ -165,7 +166,7 @@ export default function EvolutionList({ collaborators, timeRange = '12m' }) {
                   <td className="px-4 py-4 text-right">
                     {collab.joinedAt ? (
                       <span className="text-xs text-slate-500 tabular-nums">
-                        {new Date(collab.joinedAt).toLocaleDateString('en-US', { month: 'short', year: 'numeric' })}
+                        {formatDateOnlyMonthYear(collab.joinedAt)}
                       </span>
                     ) : (
                       <span className="text-xs text-slate-400 italic">--</span>

--- a/client/src/components/settings/CollaboratorSelect.jsx
+++ b/client/src/components/settings/CollaboratorSelect.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef } from 'react';
+import { createPortal } from 'react-dom';
 import { User, ChevronDown, Search } from 'lucide-react';
 
 /**
@@ -8,38 +9,77 @@ import { User, ChevronDown, Search } from 'lucide-react';
  * - value: selected collaborator id (or null)
  * - onChange: (id) => void
  * - disabled: boolean (optional) - renders static text when true
+ *
+ * The options panel is rendered into a React portal with fixed positioning so
+ * it escapes parent containers that have `overflow-hidden` (e.g. modal dialogs).
  */
 export default function CollaboratorSelect({ collaborators, value, onChange, disabled = false }) {
   const [isOpen, setIsOpen] = useState(false);
   const [search, setSearch] = useState('');
-  const containerRef = useRef(null);
+  const [dropdownStyle, setDropdownStyle] = useState({});
+  const triggerRef = useRef(null);
+  const dropdownRef = useRef(null);
 
   const selected = collaborators.find(c => c.id === value);
 
-  // Close on outside click
+  // Position panel relative to the trigger; flips above when there's no room below.
+  const updatePosition = () => {
+    if (!triggerRef.current) return;
+    const rect = triggerRef.current.getBoundingClientRect();
+    const spaceBelow = window.innerHeight - rect.bottom;
+    const spaceAbove = rect.top;
+    const maxH = Math.min(Math.max(spaceBelow, spaceAbove) - 20, 360);
+    const openUp = spaceAbove > spaceBelow;
+
+    setDropdownStyle({
+      position: 'fixed',
+      left: rect.left,
+      width: rect.width,
+      maxHeight: maxH,
+      ...(openUp
+        ? { bottom: window.innerHeight - rect.top + 4 }
+        : { top: rect.bottom + 4 }
+      ),
+    });
+  };
+
+  // Position on open + reposition on scroll/resize while open
+  useEffect(() => {
+    if (!isOpen) return;
+    updatePosition();
+    const handle = () => updatePosition();
+    window.addEventListener('scroll', handle, true);
+    window.addEventListener('resize', handle);
+    return () => {
+      window.removeEventListener('scroll', handle, true);
+      window.removeEventListener('resize', handle);
+    };
+  }, [isOpen]);
+
+  // Close on outside click / Escape
   useEffect(() => {
     if (!isOpen) return;
     const handleClick = (e) => {
-      if (containerRef.current && !containerRef.current.contains(e.target)) {
+      if (
+        triggerRef.current && !triggerRef.current.contains(e.target) &&
+        dropdownRef.current && !dropdownRef.current.contains(e.target)
+      ) {
         setIsOpen(false);
         setSearch('');
       }
     };
-    document.addEventListener('mousedown', handleClick);
-    return () => document.removeEventListener('mousedown', handleClick);
-  }, [isOpen]);
-
-  // Close on Escape
-  useEffect(() => {
-    if (!isOpen) return;
     const handleKey = (e) => {
       if (e.key === 'Escape') {
         setIsOpen(false);
         setSearch('');
       }
     };
+    document.addEventListener('mousedown', handleClick);
     document.addEventListener('keydown', handleKey);
-    return () => document.removeEventListener('keydown', handleKey);
+    return () => {
+      document.removeEventListener('mousedown', handleClick);
+      document.removeEventListener('keydown', handleKey);
+    };
   }, [isOpen]);
 
   const filtered = collaborators.filter(c =>
@@ -69,9 +109,10 @@ export default function CollaboratorSelect({ collaborators, value, onChange, dis
   }
 
   return (
-    <div className="relative w-full" ref={containerRef}>
+    <div className="relative w-full">
       {/* Trigger button */}
       <button
+        ref={triggerRef}
         type="button"
         onClick={() => setIsOpen(!isOpen)}
         aria-haspopup="listbox"
@@ -92,11 +133,17 @@ export default function CollaboratorSelect({ collaborators, value, onChange, dis
         <ChevronDown size={14} className={`text-gray-400 flex-shrink-0 transition-transform duration-200 ${isOpen ? 'rotate-180' : ''}`} />
       </button>
 
-      {/* Dropdown panel */}
-      {isOpen && (
-        <div className="absolute top-full left-0 right-0 mt-1 bg-white rounded-lg border border-gray-200 shadow-lg z-30 overflow-hidden" role="listbox" aria-label="Select collaborator">
+      {/* Dropdown panel — rendered via portal so it escapes modal overflow:hidden */}
+      {isOpen && createPortal(
+        <div
+          ref={dropdownRef}
+          style={dropdownStyle}
+          role="listbox"
+          aria-label="Select collaborator"
+          className="bg-white rounded-lg border border-gray-200 shadow-lg z-[9999] overflow-hidden flex flex-col"
+        >
           {/* Search input */}
-          <div className="p-2 border-b border-gray-100">
+          <div className="p-2 border-b border-gray-100 flex-shrink-0">
             <div className="relative">
               <Search size={14} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-gray-400" />
               <input
@@ -111,7 +158,7 @@ export default function CollaboratorSelect({ collaborators, value, onChange, dis
           </div>
 
           {/* Options list */}
-          <div className="max-h-[280px] overflow-y-auto">
+          <div className="overflow-y-auto">
             {filtered.length === 0 ? (
               <div className="px-3 py-4 text-sm text-gray-400 text-center">No results</div>
             ) : (
@@ -190,7 +237,8 @@ export default function CollaboratorSelect({ collaborators, value, onChange, dis
               </>
             )}
           </div>
-        </div>
+        </div>,
+        document.body
       )}
     </div>
   );

--- a/client/src/components/settings/CollaboratorSelect.jsx
+++ b/client/src/components/settings/CollaboratorSelect.jsx
@@ -22,14 +22,18 @@ export default function CollaboratorSelect({ collaborators, value, onChange, dis
 
   const selected = collaborators.find(c => c.id === value);
 
-  // Position panel relative to the trigger; flips above when there's no room below.
+  // Position panel relative to the trigger. Prefer opening downward; only
+  // flip up when the panel doesn't fit below AND there's more room above.
   const updatePosition = () => {
     if (!triggerRef.current) return;
     const rect = triggerRef.current.getBoundingClientRect();
     const spaceBelow = window.innerHeight - rect.bottom;
     const spaceAbove = rect.top;
-    const maxH = Math.min(Math.max(spaceBelow, spaceAbove) - 20, 360);
-    const openUp = spaceAbove > spaceBelow;
+    const PREFERRED_HEIGHT = 360;
+    const MARGIN = 20;
+    const fitsBelow = spaceBelow >= 200;
+    const openUp = !fitsBelow && spaceAbove > spaceBelow;
+    const maxH = Math.min(openUp ? spaceAbove - MARGIN : spaceBelow - MARGIN, PREFERRED_HEIGHT);
 
     setDropdownStyle({
       position: 'fixed',

--- a/client/src/components/settings/DevelopmentActionFormModal.jsx
+++ b/client/src/components/settings/DevelopmentActionFormModal.jsx
@@ -20,7 +20,7 @@ export default function ActionFormModal({ action = null, onClose, onSubmit }) {
 
   const [form, setForm] = useState({
     title: action?.title || '',
-    type: action?.type || 'experience',
+    actionType: action?.actionType || 'experience',
     description: action?.description || '',
     dueDate: action?.dueDate?.slice(0, 10) || '',
   });
@@ -78,12 +78,12 @@ export default function ActionFormModal({ action = null, onClose, onSubmit }) {
             <div className="grid grid-cols-2 gap-2">
               {ACTION_TYPES.map(t => {
                 const Icon = t.icon;
-                const selected = form.type === t.id;
+                const selected = form.actionType === t.id;
                 return (
                   <button
                     key={t.id}
                     type="button"
-                    onClick={() => setForm(prev => ({ ...prev, type: t.id }))}
+                    onClick={() => setForm(prev => ({ ...prev, actionType: t.id }))}
                     className={`flex items-center gap-2 px-3 py-2 rounded-lg border text-sm text-left transition-colors ${
                       selected
                         ? 'border-primary bg-primary/5 text-primary'

--- a/client/src/components/settings/DevelopmentGoalFormModal.jsx
+++ b/client/src/components/settings/DevelopmentGoalFormModal.jsx
@@ -97,7 +97,7 @@ export default function GoalFormModal({ goal = null, collaboratorId, skills: pro
   useFocusTrap();
 
   const inputClass = 'w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary transition-colors';
-  const selectClass = 'w-full px-3 py-2 rounded-lg border border-gray-200 bg-white text-sm text-gray-800 focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary appearance-none cursor-pointer';
+  const selectClass = 'w-full px-3 py-2 border border-gray-200 rounded-lg text-sm bg-white text-gray-800 focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary cursor-pointer transition-colors';
   const labelClass = 'block text-xs text-gray-400 uppercase tracking-wide mb-1';
 
   return createPortal(

--- a/client/src/components/settings/DevelopmentGoalFormModal.jsx
+++ b/client/src/components/settings/DevelopmentGoalFormModal.jsx
@@ -3,6 +3,7 @@ import useFocusTrap from '../../hooks/useFocusTrap';
 import { createPortal } from 'react-dom';
 import { X } from 'lucide-react';
 import Button from '../common/Button';
+import Select from '../common/Select';
 import GapSuggestions from '../development/GapSuggestions';
 import SkillSelect from './SkillSelect';
 import { useAuth } from '../../contexts/AuthContext';
@@ -97,7 +98,6 @@ export default function GoalFormModal({ goal = null, collaboratorId, skills: pro
   useFocusTrap();
 
   const inputClass = 'w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary transition-colors';
-  const selectClass = 'w-full px-3 py-2 border border-gray-200 rounded-lg text-sm bg-white text-gray-800 focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary cursor-pointer transition-colors';
   const labelClass = 'block text-xs text-gray-400 uppercase tracking-wide mb-1';
 
   return createPortal(
@@ -150,21 +150,27 @@ export default function GoalFormModal({ goal = null, collaboratorId, skills: pro
             </div>
             <div>
               <label className={labelClass}>Target Level</label>
-              <select name="targetLevel" value={form.targetLevel} onChange={handleChange} className={selectClass}>
-                {[1, 1.5, 2, 2.5, 3, 3.5, 4, 4.5, 5].map(n => (
-                  <option key={n} value={n}>{n.toFixed(1)}</option>
-                ))}
-              </select>
+              <Select
+                name="targetLevel"
+                value={form.targetLevel}
+                onChange={(v) => setForm(prev => ({ ...prev, targetLevel: v }))}
+                options={[1, 1.5, 2, 2.5, 3, 3.5, 4, 4.5, 5].map(n => ({ value: n, label: n.toFixed(1) }))}
+              />
             </div>
           </div>
 
           <div>
             <label className={labelClass}>Priority</label>
-            <select name="priority" value={form.priority} onChange={(e) => setForm(prev => ({ ...prev, priority: parseInt(e.target.value, 10) }))} className={selectClass}>
-              <option value={1}>High</option>
-              <option value={2}>Medium</option>
-              <option value={3}>Low</option>
-            </select>
+            <Select
+              name="priority"
+              value={form.priority}
+              onChange={(v) => setForm(prev => ({ ...prev, priority: v }))}
+              options={[
+                { value: 1, label: 'High' },
+                { value: 2, label: 'Medium' },
+                { value: 3, label: 'Low' },
+              ]}
+            />
           </div>
 
           {/* Gap suggestions */}

--- a/client/src/components/settings/DevelopmentPlanFormModal.jsx
+++ b/client/src/components/settings/DevelopmentPlanFormModal.jsx
@@ -58,7 +58,7 @@ export default function PlanFormModal({ plan = null, onClose, onSubmit }) {
   useFocusTrap();
 
   const inputClass = 'w-full px-3 py-2 border border-gray-200 rounded-lg text-sm bg-white focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary transition-colors';
-  const selectClass = 'w-full px-3 py-2 border border-gray-200 rounded-lg text-sm bg-white focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary appearance-none cursor-pointer transition-colors';
+  const selectClass = 'w-full px-3 py-2 border border-gray-200 rounded-lg text-sm bg-white focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary cursor-pointer transition-colors';
   const labelClass = 'block text-xs text-gray-400 uppercase tracking-wide mb-1';
 
   return createPortal(

--- a/client/src/components/settings/DevelopmentPlanFormModal.jsx
+++ b/client/src/components/settings/DevelopmentPlanFormModal.jsx
@@ -3,6 +3,7 @@ import useFocusTrap from '../../hooks/useFocusTrap';
 import { createPortal } from 'react-dom';
 import { X } from 'lucide-react';
 import Button from '../common/Button';
+import Select from '../common/Select';
 import CollaboratorSelect from './CollaboratorSelect.jsx';
 import { useAuth } from '../../contexts/AuthContext';
 import { API_BASE } from '../../lib/apiBase';
@@ -58,7 +59,6 @@ export default function PlanFormModal({ plan = null, onClose, onSubmit }) {
   useFocusTrap();
 
   const inputClass = 'w-full px-3 py-2 border border-gray-200 rounded-lg text-sm bg-white focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary transition-colors';
-  const selectClass = 'w-full px-3 py-2 border border-gray-200 rounded-lg text-sm bg-white focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary cursor-pointer transition-colors';
   const labelClass = 'block text-xs text-gray-400 uppercase tracking-wide mb-1';
 
   return createPortal(
@@ -122,12 +122,17 @@ export default function PlanFormModal({ plan = null, onClose, onSubmit }) {
           {isEdit && (
             <div>
               <label className={labelClass}>Status</label>
-              <select name="status" value={form.status} onChange={handleChange} className={selectClass}>
-                <option value="draft">Draft</option>
-                <option value="active">Active</option>
-                <option value="completed">Completed</option>
-                <option value="cancelled">Cancelled</option>
-              </select>
+              <Select
+                name="status"
+                value={form.status}
+                onChange={(v) => setForm(prev => ({ ...prev, status: v }))}
+                options={[
+                  { value: 'draft', label: 'Draft' },
+                  { value: 'active', label: 'Active' },
+                  { value: 'completed', label: 'Completed' },
+                  { value: 'cancelled', label: 'Cancelled' },
+                ]}
+              />
             </div>
           )}
 

--- a/client/src/components/settings/DevelopmentTab.jsx
+++ b/client/src/components/settings/DevelopmentTab.jsx
@@ -376,6 +376,29 @@ export default function DevelopmentTab({ isActive }) {
     })));
   };
 
+  // Full edit submission from ActionFormModal (mode='edit')
+  const handleEditAction = async (formData) => {
+    try {
+      const { action } = actionModal;
+      const res = await authFetch(`${API_BASE}/api/development-actions/${action.id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(formData),
+      });
+      if (res.status === 403) { toast.error('This action is not available in demo mode'); setActionModal(null); return; }
+      if (!res.ok) throw new Error('Failed to update action');
+      toast.success('Action updated');
+      setActionModal(null);
+      if (expandedPlanId) refetchPlanDetail(expandedPlanId);
+    } catch (err) {
+      if (err.message === 'SESSION_EXPIRED') {
+        setShowLogin(true);
+      } else {
+        toast.error('Failed to update action');
+      }
+    }
+  };
+
   const handleActionStatusChange = async (actionId, newStatus) => {
     try {
       const res = await authFetch(`${API_BASE}/api/development-actions/${actionId}`, {
@@ -833,15 +856,24 @@ export default function DevelopmentTab({ isActive }) {
                                               </span>
                                             )}
 
-                                            {/* Delete */}
-                                            {canEdit && (
-                                            <button
-                                              onClick={() => setDeleteActionTarget(action)}
-                                              className="flex-shrink-0 text-gray-300 hover:text-critical transition-colors opacity-0 group-hover:opacity-100"
-                                              title="Delete action"
-                                            >
-                                              <Trash2 size={14} />
-                                            </button>
+                                            {/* Edit / Delete — allowed whenever the plan can be deleted (not completed) */}
+                                            {canDelete && (
+                                            <div className="flex-shrink-0 flex items-center gap-1 opacity-0 group-hover:opacity-100">
+                                              <button
+                                                onClick={() => setActionModal({ mode: 'edit', action })}
+                                                className="text-gray-300 hover:text-primary transition-colors"
+                                                title="Edit action"
+                                              >
+                                                <Edit2 size={14} />
+                                              </button>
+                                              <button
+                                                onClick={() => setDeleteActionTarget(action)}
+                                                className="text-gray-300 hover:text-critical transition-colors"
+                                                title="Delete action"
+                                              >
+                                                <Trash2 size={14} />
+                                              </button>
+                                            </div>
                                             )}
                                           </div>
                                         );
@@ -953,7 +985,7 @@ export default function DevelopmentTab({ isActive }) {
         <ActionFormModal
           action={actionModal.mode === 'edit' ? actionModal.action : null}
           onClose={() => setActionModal(null)}
-          onSubmit={handleCreateAction}
+          onSubmit={actionModal.mode === 'edit' ? handleEditAction : handleCreateAction}
         />
       )}
 

--- a/client/src/components/settings/DevelopmentTab.jsx
+++ b/client/src/components/settings/DevelopmentTab.jsx
@@ -856,9 +856,9 @@ export default function DevelopmentTab({ isActive }) {
                                               </span>
                                             )}
 
-                                            {/* Edit / Delete — same spacing as plan-level icons (p-1.5 + gap-1.5) */}
+                                            {/* Edit / Delete — same spacing as plan-level icons (p-1.5 + gap-1) */}
                                             {canDelete && (
-                                            <div className="flex-shrink-0 flex items-center gap-1.5 opacity-0 group-hover:opacity-100">
+                                            <div className="flex-shrink-0 flex items-center gap-1 opacity-0 group-hover:opacity-100">
                                               <button
                                                 onClick={() => setActionModal({ mode: 'edit', action })}
                                                 className="p-1.5 text-gray-400 hover:text-primary rounded transition-colors"

--- a/client/src/components/settings/DevelopmentTab.jsx
+++ b/client/src/components/settings/DevelopmentTab.jsx
@@ -747,8 +747,10 @@ export default function DevelopmentTab({ isActive }) {
                                   </span>
                                 )}
 
-                                {/* Edit / Delete */}
-                                {canEdit && (
+                                {/* Edit / Delete — allowed whenever the plan can be deleted (not completed).
+                                    Cancelled plans still allow goal-level corrections so a user can clean up
+                                    or fix mistakes before/after a plan is abandoned. */}
+                                {canDelete && (
                                 <div className="flex items-center gap-1 flex-shrink-0" onClick={(e) => e.stopPropagation()}>
                                   <button
                                     onClick={() => setGoalModal({ mode: 'edit', goal })}
@@ -794,7 +796,7 @@ export default function DevelopmentTab({ isActive }) {
                                     <div className="space-y-1">
                                       {actions.map(action => {
                                         const isCompleted = action.status === 'completed';
-                                        const typeConfig = ACTION_TYPE_BADGES[action.type] || ACTION_TYPE_BADGES.experience;
+                                        const typeConfig = ACTION_TYPE_BADGES[action.actionType] || ACTION_TYPE_BADGES.experience;
 
                                         return (
                                           <div

--- a/client/src/components/settings/DevelopmentTab.jsx
+++ b/client/src/components/settings/DevelopmentTab.jsx
@@ -856,19 +856,19 @@ export default function DevelopmentTab({ isActive }) {
                                               </span>
                                             )}
 
-                                            {/* Edit / Delete — allowed whenever the plan can be deleted (not completed) */}
+                                            {/* Edit / Delete — same spacing as plan-level icons (p-1.5 + gap-1.5) */}
                                             {canDelete && (
-                                            <div className="flex-shrink-0 flex items-center gap-1 opacity-0 group-hover:opacity-100">
+                                            <div className="flex-shrink-0 flex items-center gap-1.5 opacity-0 group-hover:opacity-100">
                                               <button
                                                 onClick={() => setActionModal({ mode: 'edit', action })}
-                                                className="text-gray-300 hover:text-primary transition-colors"
+                                                className="p-1.5 text-gray-400 hover:text-primary rounded transition-colors"
                                                 title="Edit action"
                                               >
                                                 <Edit2 size={14} />
                                               </button>
                                               <button
                                                 onClick={() => setDeleteActionTarget(action)}
-                                                className="text-gray-300 hover:text-critical transition-colors"
+                                                className="p-1.5 text-gray-400 hover:text-critical rounded transition-colors"
                                                 title="Delete action"
                                               >
                                                 <Trash2 size={14} />

--- a/client/src/components/settings/SkillSelect.jsx
+++ b/client/src/components/settings/SkillSelect.jsx
@@ -84,14 +84,18 @@ export default function SkillSelect({ skills, categories, collaboratorId, value,
   const otherCount = Object.values(otherSkillsByCategory).reduce((sum, arr) => sum + arr.length, 0);
   const hasRoleSkills = roleSkills.length > 0;
 
-  // Calculate dropdown position
+  // Calculate dropdown position. Prefer opening downward; only flip up when
+  // the panel doesn't fit below AND there's more room above.
   const updatePosition = () => {
     if (!triggerRef.current) return;
     const rect = triggerRef.current.getBoundingClientRect();
     const spaceBelow = window.innerHeight - rect.bottom;
     const spaceAbove = rect.top;
-    const maxH = Math.min(Math.max(spaceBelow, spaceAbove) - 20, 350);
-    const openUp = spaceAbove > spaceBelow;
+    const PREFERRED_HEIGHT = 350;
+    const MARGIN = 20;
+    const fitsBelow = spaceBelow >= 200;
+    const openUp = !fitsBelow && spaceAbove > spaceBelow;
+    const maxH = Math.min(openUp ? spaceAbove - MARGIN : spaceBelow - MARGIN, PREFERRED_HEIGHT);
 
     setDropdownStyle({
       position: 'fixed',

--- a/client/src/components/settings/__tests__/DevelopmentActionFormModal.test.jsx
+++ b/client/src/components/settings/__tests__/DevelopmentActionFormModal.test.jsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import ActionFormModal from '../DevelopmentActionFormModal';
+
+// jsdom: createPortal requires document.body
+beforeEach(() => {
+  document.body.innerHTML = '';
+});
+
+const renderModal = (props = {}) => {
+  const defaultProps = {
+    onClose: vi.fn(),
+    onSubmit: vi.fn().mockResolvedValue(undefined),
+    ...props,
+  };
+  return { ...render(<ActionFormModal {...defaultProps} />), props: defaultProps };
+};
+
+describe('DevelopmentActionFormModal', () => {
+  it('submits payload with actionType field (not legacy "type")', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    renderModal({ onSubmit });
+
+    fireEvent.change(screen.getByPlaceholderText(/Complete React Testing course/i), {
+      target: { value: 'My new action' },
+    });
+
+    // Click the "Formal (10%)" type tile
+    fireEvent.click(screen.getByText(/Formal/i).closest('button'));
+
+    fireEvent.click(screen.getByRole('button', { name: /Add Action/i }));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    const payload = onSubmit.mock.calls[0][0];
+    expect(payload.actionType).toBe('formal');
+    expect(payload.title).toBe('My new action');
+    // The legacy "type" field must not be present (or must equal actionType)
+    expect(payload.type).toBeUndefined();
+  });
+
+  it('defaults actionType to "experience" when no selection made', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    renderModal({ onSubmit });
+
+    fireEvent.change(screen.getByPlaceholderText(/Complete React Testing course/i), {
+      target: { value: 'Default type action' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Add Action/i }));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    expect(onSubmit.mock.calls[0][0].actionType).toBe('experience');
+  });
+
+  it('pre-fills actionType when editing an existing action', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    const existing = {
+      id: 7,
+      title: 'Existing action',
+      actionType: 'social',
+      description: 'Mentoring session',
+      dueDate: null,
+    };
+    renderModal({ action: existing, onSubmit });
+
+    // Modal title should reflect edit mode
+    expect(screen.getByText('Edit Action')).toBeInTheDocument();
+
+    // Submit without changing — payload must keep actionType: 'social'
+    fireEvent.click(screen.getByRole('button', { name: /Save Changes/i }));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    expect(onSubmit.mock.calls[0][0].actionType).toBe('social');
+  });
+
+  // Bug #34: dropdowns must not hide the native chevron (no `appearance-none` class)
+  // Otherwise the select looks like a text input. Action form uses tile buttons (no select),
+  // but type tile buttons must remain visually distinct from inputs.
+  it('renders type tiles with visible affordance (not as a hidden select)', () => {
+    renderModal();
+    // The "Formal" tile should be a clickable button with border styling
+    const formalTile = screen.getByText(/Formal/i).closest('button');
+    expect(formalTile).toBeInTheDocument();
+    expect(formalTile.className).toMatch(/border/);
+  });
+
+  it('persists changed actionType when editing', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    const existing = {
+      id: 7,
+      title: 'Existing action',
+      actionType: 'experience',
+      description: '',
+      dueDate: null,
+    };
+    renderModal({ action: existing, onSubmit });
+
+    // Change to Self-directed
+    fireEvent.click(screen.getByText(/Self-directed/i).closest('button'));
+    fireEvent.click(screen.getByRole('button', { name: /Save Changes/i }));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    expect(onSubmit.mock.calls[0][0].actionType).toBe('self_directed');
+  });
+});

--- a/client/src/components/settings/__tests__/DevelopmentGoalFormModal.test.jsx
+++ b/client/src/components/settings/__tests__/DevelopmentGoalFormModal.test.jsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import GoalFormModal from '../DevelopmentGoalFormModal';
 
 vi.mock('../../../contexts/AuthContext', () => ({
@@ -22,28 +22,43 @@ const renderModal = (props = {}) => render(
 );
 
 describe('DevelopmentGoalFormModal — dropdown styling (bug #34)', () => {
-  it('Target Level select shows native chevron (no appearance-none)', () => {
+  // After bug #34, native <select> elements were replaced with the custom
+  // Select component (button + portal panel) used elsewhere in the app.
+  it('Target Level uses the custom Select (no native <select> element)', () => {
     renderModal();
-    const targetSelect = document.querySelector('select[name="targetLevel"]');
-    expect(targetSelect).toBeInTheDocument();
-    // appearance-none would hide the native dropdown chevron, making the select
-    // look like a plain text input — that was bug #34.
-    expect(targetSelect.className).not.toMatch(/appearance-none/);
+    const nativeSelect = document.querySelector('select[name="targetLevel"]');
+    expect(nativeSelect).toBeNull();
+    // The trigger button exposes name="targetLevel"
+    const trigger = document.querySelector('button[name="targetLevel"]');
+    expect(trigger).toBeInTheDocument();
+    expect(trigger).toHaveAttribute('aria-haspopup', 'listbox');
   });
 
-  it('Priority select shows native chevron (no appearance-none)', () => {
+  it('Priority uses the custom Select', () => {
     renderModal();
-    const prioritySelect = document.querySelector('select[name="priority"]');
-    expect(prioritySelect).toBeInTheDocument();
-    expect(prioritySelect.className).not.toMatch(/appearance-none/);
+    expect(document.querySelector('select[name="priority"]')).toBeNull();
+    const trigger = document.querySelector('button[name="priority"]');
+    expect(trigger).toBeInTheDocument();
+    expect(trigger).toHaveAttribute('aria-haspopup', 'listbox');
   });
 
-  it('Priority select uses the same styling tokens as the rest of the app', () => {
+  it('Priority dropdown shows High/Medium/Low options when opened', () => {
     renderModal();
-    const prioritySelect = document.querySelector('select[name="priority"]');
-    // Canonical tokens used across the app's selects/inputs
-    expect(prioritySelect.className).toMatch(/border-gray-200/);
-    expect(prioritySelect.className).toMatch(/rounded-lg/);
-    expect(prioritySelect.className).toMatch(/focus:ring-primary/);
+    const trigger = document.querySelector('button[name="priority"]');
+    fireEvent.click(trigger);
+    // Panel renders into document.body via portal
+    expect(screen.getByRole('option', { name: 'High' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Medium' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Low' })).toBeInTheDocument();
+  });
+
+  it('Selecting a Priority option calls onChange with the option value', () => {
+    const onSubmit = vi.fn();
+    renderModal({ onSubmit });
+    const trigger = document.querySelector('button[name="priority"]');
+    fireEvent.click(trigger);
+    fireEvent.click(screen.getByRole('option', { name: 'Low' }));
+    // The trigger label should now show 'Low'
+    expect(trigger.textContent).toContain('Low');
   });
 });

--- a/client/src/components/settings/__tests__/DevelopmentGoalFormModal.test.jsx
+++ b/client/src/components/settings/__tests__/DevelopmentGoalFormModal.test.jsx
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import GoalFormModal from '../DevelopmentGoalFormModal';
+
+vi.mock('../../../contexts/AuthContext', () => ({
+  useAuth: () => ({ authFetch: vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({ skills: [], categories: [] }) }) }),
+}));
+vi.mock('../../../lib/apiBase', () => ({ API_BASE: '' }));
+vi.mock('../SkillSelect', () => ({
+  default: () => <div data-testid="skill-select" />,
+}));
+vi.mock('../../development/GapSuggestions', () => ({
+  default: () => <div data-testid="gap-suggestions" />,
+}));
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+});
+
+const renderModal = (props = {}) => render(
+  <GoalFormModal collaboratorId={1} onClose={vi.fn()} onSubmit={vi.fn()} {...props} />
+);
+
+describe('DevelopmentGoalFormModal — dropdown styling (bug #34)', () => {
+  it('Target Level select shows native chevron (no appearance-none)', () => {
+    renderModal();
+    const targetSelect = document.querySelector('select[name="targetLevel"]');
+    expect(targetSelect).toBeInTheDocument();
+    // appearance-none would hide the native dropdown chevron, making the select
+    // look like a plain text input — that was bug #34.
+    expect(targetSelect.className).not.toMatch(/appearance-none/);
+  });
+
+  it('Priority select shows native chevron (no appearance-none)', () => {
+    renderModal();
+    const prioritySelect = document.querySelector('select[name="priority"]');
+    expect(prioritySelect).toBeInTheDocument();
+    expect(prioritySelect.className).not.toMatch(/appearance-none/);
+  });
+
+  it('Priority select uses the same styling tokens as the rest of the app', () => {
+    renderModal();
+    const prioritySelect = document.querySelector('select[name="priority"]');
+    // Canonical tokens used across the app's selects/inputs
+    expect(prioritySelect.className).toMatch(/border-gray-200/);
+    expect(prioritySelect.className).toMatch(/rounded-lg/);
+    expect(prioritySelect.className).toMatch(/focus:ring-primary/);
+  });
+});

--- a/client/src/components/settings/__tests__/DevelopmentTab.test.jsx
+++ b/client/src/components/settings/__tests__/DevelopmentTab.test.jsx
@@ -564,6 +564,73 @@ describe('DevelopmentTab', () => {
     });
   });
 
+  // --- Action edit visibility (bug #35 follow-up: actions only had delete) ---
+  describe('Action edit/delete buttons by plan status (bug #35 follow-up)', () => {
+    function planWithGoalAndAction(basePlan, actionOverrides = {}) {
+      return {
+        ...basePlan,
+        goals: [
+          {
+            id: 600,
+            title: 'Goal w/ action',
+            description: '',
+            status: 'active',
+            priority: 'medium',
+            actions: [
+              {
+                id: 700,
+                title: 'My Action',
+                actionType: 'experience',
+                status: 'not_started',
+                ...actionOverrides,
+              },
+            ],
+          },
+        ],
+      };
+    }
+
+    async function expandPlanAndGoal(planTitle) {
+      await waitFor(() => screen.getByText(planTitle));
+      fireEvent.click(screen.getByText(planTitle).closest('[role="button"]'));
+      await waitFor(() => screen.getByText('Goal w/ action'));
+      fireEvent.click(screen.getByText('Goal w/ action').closest('[role="button"]'));
+    }
+
+    it('shows Edit action button on ACTIVE plan', async () => {
+      setupFetch([planWithGoalAndAction(mockActivePlan)]);
+      renderTab();
+      await expandPlanAndGoal('Q2 Growth Plan');
+      await waitFor(() => screen.getByText('My Action'));
+      expect(screen.getByTitle('Edit action')).toBeInTheDocument();
+    });
+
+    it('shows Edit action button on CANCELLED plan', async () => {
+      setupFetch([planWithGoalAndAction(mockCancelledPlan)]);
+      renderTab();
+      await expandPlanAndGoal('Cancelled Initiative');
+      await waitFor(() => screen.getByText('My Action'));
+      expect(screen.getByTitle('Edit action')).toBeInTheDocument();
+    });
+
+    it('hides Edit action button on COMPLETED plan (frozen record)', async () => {
+      setupFetch([planWithGoalAndAction(mockCompletedPlan)]);
+      renderTab();
+      await expandPlanAndGoal('Onboarding Plan');
+      await waitFor(() => screen.getByText('My Action'));
+      expect(screen.queryByTitle('Edit action')).not.toBeInTheDocument();
+    });
+
+    it('clicking Edit action opens the action form modal', async () => {
+      setupFetch([planWithGoalAndAction(mockActivePlan)]);
+      renderTab();
+      await expandPlanAndGoal('Q2 Growth Plan');
+      await waitFor(() => screen.getByText('My Action'));
+      fireEvent.click(screen.getByTitle('Edit action'));
+      await waitFor(() => expect(screen.getByTestId('action-form-modal')).toBeInTheDocument());
+    });
+  });
+
   // --- ActionStatusDropdown disabled state ---
   describe('ActionStatusDropdown disabled for completed/cancelled plans', () => {
     function makePlanWithAction(basePlan, actionStatus = 'not_started') {

--- a/client/src/components/settings/__tests__/DevelopmentTab.test.jsx
+++ b/client/src/components/settings/__tests__/DevelopmentTab.test.jsx
@@ -487,6 +487,83 @@ describe('DevelopmentTab', () => {
     });
   });
 
+  // --- Goal-level edit/delete visibility (bug #35) ---
+  describe('Goal edit/delete buttons by plan status (bug #35)', () => {
+    function planWithGoal(basePlan, goalOverrides = {}) {
+      return {
+        ...basePlan,
+        goals: [
+          {
+            id: 500,
+            title: 'Editable Goal',
+            description: '',
+            status: 'active',
+            priority: 'medium',
+            targetLevel: 4,
+            actions: [],
+            ...goalOverrides,
+          },
+        ],
+      };
+    }
+
+    async function expandPlan(title) {
+      await waitFor(() => screen.getByText(title));
+      fireEvent.click(screen.getByText(title).closest('[role="button"]'));
+    }
+
+    it('shows Edit goal button on ACTIVE plan', async () => {
+      setupFetch([planWithGoal(mockActivePlan)]);
+      renderTab();
+      await expandPlan('Q2 Growth Plan');
+      await waitFor(() => screen.getByText('Editable Goal'));
+      expect(screen.getByTitle('Edit goal')).toBeInTheDocument();
+    });
+
+    it('shows Edit goal button on DRAFT plan', async () => {
+      setupFetch([planWithGoal(mockDraftPlan)]);
+      renderTab();
+      await expandPlan('Backend Upskilling');
+      await waitFor(() => screen.getByText('Editable Goal'));
+      expect(screen.getByTitle('Edit goal')).toBeInTheDocument();
+    });
+
+    it('shows Edit goal button on CANCELLED plan (regression: was hidden)', async () => {
+      setupFetch([planWithGoal(mockCancelledPlan)]);
+      renderTab();
+      await expandPlan('Cancelled Initiative');
+      await waitFor(() => screen.getByText('Editable Goal'));
+      expect(screen.getByTitle('Edit goal')).toBeInTheDocument();
+    });
+
+    it('shows Delete goal button on CANCELLED plan', async () => {
+      setupFetch([planWithGoal(mockCancelledPlan)]);
+      renderTab();
+      await expandPlan('Cancelled Initiative');
+      await waitFor(() => screen.getByText('Editable Goal'));
+      expect(screen.getByTitle('Delete goal')).toBeInTheDocument();
+    });
+
+    it('hides Edit and Delete goal buttons on COMPLETED plan (frozen record)', async () => {
+      setupFetch([planWithGoal(mockCompletedPlan)]);
+      renderTab();
+      await expandPlan('Onboarding Plan');
+      await waitFor(() => screen.getByText('Editable Goal'));
+      expect(screen.queryByTitle('Edit goal')).not.toBeInTheDocument();
+      expect(screen.queryByTitle('Delete goal')).not.toBeInTheDocument();
+    });
+
+    it('clicking Edit goal opens the goal form modal in edit mode', async () => {
+      setupFetch([planWithGoal(mockActivePlan)]);
+      renderTab();
+      await expandPlan('Q2 Growth Plan');
+      await waitFor(() => screen.getByText('Editable Goal'));
+      fireEvent.click(screen.getByTitle('Edit goal'));
+      // GoalFormModal is mocked; verify the modal opened
+      await waitFor(() => expect(screen.getByTestId('goal-form-modal')).toBeInTheDocument());
+    });
+  });
+
   // --- ActionStatusDropdown disabled state ---
   describe('ActionStatusDropdown disabled for completed/cancelled plans', () => {
     function makePlanWithAction(basePlan, actionStatus = 'not_started') {
@@ -502,7 +579,7 @@ describe('DevelopmentTab', () => {
               {
                 id: 300,
                 title: 'Test Action',
-                type: 'experience',
+                actionType: 'experience',
                 status: actionStatus,
               },
             ],

--- a/client/src/lib/timeLogic.js
+++ b/client/src/lib/timeLogic.js
@@ -258,3 +258,24 @@ export const findBestMatchingPeriod = (currentPeriodId, targetGranularity, allPe
   
   return bestFallback ? bestFallback.id : (candidates.length > 0 ? candidates[0].id : null);
 };
+
+/**
+ * Formats a date-only value (YYYY-MM-DD or ISO datetime) as "Mon YYYY" without
+ * timezone shifting. The native `new Date('2025-03-01').toLocaleDateString()`
+ * parses YYYY-MM-DD as UTC midnight, which renders as the previous day in any
+ * timezone west of UTC — collapsing month boundaries on the 1st.
+ *
+ * Bug #32 fix: extract the YYYY-MM portion and format from there.
+ */
+export const formatDateOnlyMonthYear = (value) => {
+  if (!value) return null;
+  const str = String(value);
+  const match = str.match(/^(\d{4})-(\d{2})/);
+  if (!match) return null;
+  const year = parseInt(match[1], 10);
+  const monthIdx = parseInt(match[2], 10) - 1;
+  if (monthIdx < 0 || monthIdx > 11) return null;
+  // Construct a local-noon date so toLocaleDateString never shifts months
+  const d = new Date(year, monthIdx, 1, 12, 0, 0);
+  return d.toLocaleDateString('en-US', { month: 'short', year: 'numeric' });
+};

--- a/client/src/lib/timeLogic.test.js
+++ b/client/src/lib/timeLogic.test.js
@@ -3,7 +3,8 @@ import {
     findBestMatchingPeriod,
     generateTimePeriods,
     getSnapshotData,
-    getPreviousPeriodDate
+    getPreviousPeriodDate,
+    formatDateOnlyMonthYear
 } from './timeLogic';
 
 describe('timeLogic', () => {
@@ -527,6 +528,7 @@ describe('timeLogic', () => {
             expect(prevDate.getDate()).toBe(29);
         });
 
+        // (intentionally placed at the end of getPreviousPeriodDate describe; no-op marker)
         it('should handle different quarters correctly', () => {
             // Q2 (Apr-Jun)
             const q2Date = new Date(2025, 4, 15);
@@ -542,6 +544,44 @@ describe('timeLogic', () => {
             const q4Date = new Date(2025, 10, 15);
             const prevQ4 = getPreviousPeriodDate(q4Date, 'quarter');
             expect(prevQ4.getMonth()).toBe(8); // Sep 30
+        });
+    });
+
+    // Bug #32: dates stored as UTC midnight (e.g. "2025-03-01T00:00:00.000Z" or "2025-03-01")
+    // render as the previous month in negative timezones because `new Date(...)` parses
+    // YYYY-MM-DD strings as UTC.
+    describe('formatDateOnlyMonthYear (bug #32)', () => {
+        it('parses YYYY-MM-DD as a local date (no timezone shift)', () => {
+            // Without the fix, "2025-03-01" parsed as UTC midnight becomes
+            // Feb 28 23:00:00 in UTC-1 → "Feb 2025".
+            // With the fix it must always render the stored month, regardless of timezone.
+            const result = formatDateOnlyMonthYear('2025-03-01');
+            expect(result).toBe('Mar 2025');
+        });
+
+        it('handles ISO datetime UTC midnight without month rollover', () => {
+            const result = formatDateOnlyMonthYear('2025-03-01T00:00:00.000Z');
+            expect(result).toBe('Mar 2025');
+        });
+
+        it('handles ISO datetime with offset (already-local timestamps)', () => {
+            const result = formatDateOnlyMonthYear('2025-03-01T12:00:00.000Z');
+            expect(result).toBe('Mar 2025');
+        });
+
+        it('returns null for null/undefined/empty input', () => {
+            expect(formatDateOnlyMonthYear(null)).toBeNull();
+            expect(formatDateOnlyMonthYear(undefined)).toBeNull();
+            expect(formatDateOnlyMonthYear('')).toBeNull();
+        });
+
+        it('returns null for malformed input', () => {
+            expect(formatDateOnlyMonthYear('not-a-date')).toBeNull();
+        });
+
+        it('handles January 1st (year boundary) without rollover', () => {
+            const result = formatDateOnlyMonthYear('2025-01-01');
+            expect(result).toBe('Jan 2025');
         });
     });
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skima",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "private": true,
   "description": "Skima - People Development Platform",
   "scripts": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skima-server",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "private": true,
   "type": "module",
   "bin": "src/index.js",

--- a/server/src/__tests__/evolution.test.js
+++ b/server/src/__tests__/evolution.test.js
@@ -518,4 +518,102 @@ describe('Evolution Routes', () => {
       expect(employee.sparkline).toEqual([2.0, 4.0]);
     });
   });
+
+  // ============================================
+  // Bug #31: collaborator silently dropped when role profile has no non-N skills
+  // ============================================
+  describe('Role profile fallback (bug #31)', () => {
+    async function seedWithRoleProfile(profileSkills) {
+      const category = await prisma.category.create({
+        data: { id: 50, nombre: 'Tech', abrev: 'T' }
+      });
+      const skill = await prisma.skill.create({
+        data: { id: 50, nombre: 'JS', categoriaId: category.id }
+      });
+      const collab = await prisma.collaborator.create({
+        data: { nombre: 'Orphan', rol: 'Engineer', isActive: true, joinedAt: new Date('2024-01-01') }
+      });
+      const session = await prisma.evaluationSession.create({
+        data: {
+          collaboratorId: collab.id,
+          collaboratorNombre: 'Orphan',
+          collaboratorRol: 'Engineer',
+          evaluatedAt: new Date()
+        }
+      });
+      await prisma.assessment.create({
+        data: {
+          collaboratorId: collab.id,
+          skillId: skill.id,
+          nivel: 3.5,
+          criticidad: 'C',
+          frecuencia: 'D',
+          evaluationSessionId: session.id
+        }
+      });
+      // Create the role profile with the given skills config (skillId → criticality)
+      await prisma.roleProfile.create({
+        data: {
+          rol: 'Engineer',
+          skills: JSON.stringify(profileSkills)
+        }
+      });
+      return { collab, skill, session };
+    }
+
+    it('includes the collaborator when role profile marks every skill as N', async () => {
+      // Profile says skill 50 is N (not relevant to role) — without the fallback,
+      // validAssessments ends up empty and the collaborator is silently dropped.
+      const { collab } = await seedWithRoleProfile({ '50': 'N' });
+
+      const res = await request(app).get('/api/skills/evolution');
+      const ids = res.body.employees.map(e => e.id);
+      expect(ids).toContain(collab.id);
+    });
+
+    it('includes the collaborator when role profile is empty (no skills configured)', async () => {
+      const { collab } = await seedWithRoleProfile({});
+      const res = await request(app).get('/api/skills/evolution');
+      const ids = res.body.employees.map(e => e.id);
+      expect(ids).toContain(collab.id);
+    });
+
+    it('still excludes the collaborator if every assessment has nivel <= 0 (real "no data" case)', async () => {
+      const category = await prisma.category.create({
+        data: { id: 60, nombre: 'Tech', abrev: 'T' }
+      });
+      const skill = await prisma.skill.create({
+        data: { id: 60, nombre: 'JS', categoriaId: category.id }
+      });
+      const collab = await prisma.collaborator.create({
+        data: { nombre: 'Empty', rol: 'Engineer', isActive: true, joinedAt: new Date('2024-01-01') }
+      });
+      const session = await prisma.evaluationSession.create({
+        data: {
+          collaboratorId: collab.id,
+          collaboratorNombre: 'Empty',
+          collaboratorRol: 'Engineer',
+          evaluatedAt: new Date()
+        }
+      });
+      // nivel=0 means "not evaluated" — must remain excluded even with fallback
+      await prisma.assessment.create({
+        data: {
+          collaboratorId: collab.id,
+          skillId: skill.id,
+          nivel: 0,
+          criticidad: 'C',
+          frecuencia: 'D',
+          evaluationSessionId: session.id
+        }
+      });
+      await prisma.roleProfile.create({
+        data: { rol: 'Engineer', skills: JSON.stringify({ '60': 'N' }) }
+      });
+
+      const res = await request(app).get('/api/skills/evolution');
+      const ids = res.body.employees.map(e => e.id);
+      expect(ids).not.toContain(collab.id);
+    });
+  });
 });

--- a/server/src/routes/evolution.js
+++ b/server/src/routes/evolution.js
@@ -189,27 +189,38 @@ router.get('/', async (req, res) => {
       const roleSkills = profileMap.get(cRole);
 
       // Calculate average score for this session (Smart Filter)
-      const validAssessments = session.assessments.filter(a => {
+      let validAssessments = session.assessments.filter(a => {
         // Base valid check
         if (!a.nivel || a.nivel <= 0) return false;
 
         // Inactive Skill Check
         if (a.skill && !a.skill.isActive) return false;
-        
+
         // Role Profile check (if exists)
         if (roleSkills) {
           const skillIdStr = a.skillId.toString();
           // If skill is in profile, check criticality
           // If not in profile, decided policy: Include or Exclude?
-          // Usually if profile exists, we respect it strictly. 
+          // Usually if profile exists, we respect it strictly.
           // Assuming profile contains ALL relevant skills. If not in profile -> 'N'.
           // Let's use flexible check: If defined as 'N', exclude.
-          const criticality = roleSkills[skillIdStr] || 'N'; 
+          const criticality = roleSkills[skillIdStr] || 'N';
           return criticality !== 'N';
         }
-        
-        return true; 
+
+        return true;
       });
+
+      // Bug #31 fallback: when the role profile filters out every assessment
+      // (e.g. all skills marked 'N', empty profile, role renamed/deleted, or
+      // an evaluation done before role configuration is finished), fall back to
+      // the collaborator's raw assessments instead of silently dropping them
+      // from Evolution. We still require a real evaluation (nivel > 0).
+      if (validAssessments.length === 0 && roleSkills) {
+        validAssessments = session.assessments.filter(a => (
+          a.nivel > 0 && (!a.skill || a.skill.isActive)
+        ));
+      }
 
       if (validAssessments.length === 0) return;
       

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skima"
-version = "1.3.4"
+version = "1.3.5"
 description = "Skima - People Development Platform"
 authors = ["DLSLabs"]
 edition = "2024"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Skima",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "identifier": "com.dlslabs.skima",
   "build": {
     "beforeDevCommand": "npm run dev:client",
@@ -26,7 +26,9 @@
   },
   "bundle": {
     "active": true,
-    "targets": ["nsis"],
+    "targets": [
+      "nsis"
+    ],
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",


### PR DESCRIPTION
Patch release — last manual-upgrade version. Once merged, the auto-updater work in v1.4.0 (#39) will let users self-upgrade from here on.

## Resolves

Closes #31
Closes #32
Closes #33
Closes #34
Closes #35

## Bugs fixed

### #33 — Action type dropdown did not persist
- Form sent `type` field; API expected `actionType` → every action defaulted to `experience`
- Display read `action.type` instead of `action.actionType` → wrong badge always
- Renamed everywhere; mocks fixed; 4 new unit tests cover form payload + display

### #35 — Development goals/actions could only be deleted
- **Goals:** edit button existed but was gated by `canEdit` (active/draft only). Now uses `canDelete` (any non-completed plan) — cancelled plans now allow goal corrections; completed remain a frozen record. 6 new tests.
- **Actions:** had no edit affordance at all (the user's actual report). Added Edit button + `handleEditAction` calling `PUT /api/development-actions/:id`. Same gating as goals. 4 new tests.
- Spacing of edit/delete icons matches plan-level for consistency.

### #34 — Dropdowns inconsistent with rest of app
- Native `<select>` with hidden chevron looked broken
- Created reusable `components/common/Select.jsx` (button trigger + portal panel + chevron + primary highlight + auto-flip) matching `CollaboratorSelect` / `SkillSelect` styling
- Applied to Target Level, Priority (Goal modal), Status (Plan modal)
- Bonus: refactored `CollaboratorSelect` to render via portal too — fixes the option list being clipped by modal `overflow-hidden`
- Auto-flip prefers downward (more predictable than the previous \"largest space wins\" logic), applied across `Select` / `CollaboratorSelect` / `SkillSelect`
- 4 regression tests cover custom Select usage in the goal modal

### #32 — \`joinedAt\` rendered one month earlier
- Dates stored as UTC midnight (e.g. \`2025-03-01\`) shifted to previous day in negative timezones, collapsing month boundaries on the 1st
- Added \`formatDateOnlyMonthYear\` helper in \`lib/timeLogic.js\` that parses YYYY-MM-DD as local-noon
- Applied in \`EvolutionList.jsx\`
- 6 helper tests

### #31 — Collaborator silently excluded from Evolution
- When the role profile filter dropped every assessment (all skills 'N', empty profile, role renamed/deleted, profile not yet configured) the collaborator vanished without warning
- Added fallback in \`server/src/routes/evolution.js\`: when filtering removes everything but raw assessments exist (\`nivel > 0\`), include them anyway
- The real \"no data\" case (all \`nivel <= 0\`) still excludes correctly
- 3 new server tests

## Versioning
- Bumped to **1.3.5** in: \`package.json\`, \`client/package.json\`, \`server/package.json\`, \`src-tauri/tauri.conf.json\`, \`src-tauri/Cargo.toml\`
- After merge: tag \`v1.3.5\` from \`main\` to trigger the release build workflow

## Test plan

- [x] Full client suite: 837 passing (+11 new)
- [x] Full server suite: 171 passing (+3 new)
- [x] Build clean (\`npm run build:client\`)
- [x] Manual smoke test by maintainer:
  - [x] #33 action type "Formal" persists and renders correct badge
  - [x] #34 Target Level / Priority / Status dropdowns match the rest of the app; CollaboratorSelect not clipped
  - [x] #35 goal edit on cancelled plans; action edit added with proper spacing
  - [x] #32 \`joinedAt\` displays correct month for any timezone
  - [x] #31 collaborator survives role profile with all-N skills

## Out of scope (next release)
- v1.4.0 (#41): auto-updater + IDP visibility (#36, #37, #38, #39)
- v1.4.x: Windows code signing research (#40)