### PR TITLE
chore: bump version to 1.4.0-rc.1

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "skima",
   "private": true,
-  "version": "1.3.5",
+  "version": "1.4.0-rc.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skima",
-  "version": "1.3.5",
+  "version": "1.4.0-rc.1",
   "private": true,
   "description": "Skima - People Development Platform",
   "scripts": {

--- a/scripts/bump-version.js
+++ b/scripts/bump-version.js
@@ -66,8 +66,8 @@ if (!arg) {
 const currentVersion = getCurrentVersion();
 const newVersion = bumpVersion(currentVersion, arg);
 
-// Validate semver format
-if (!/^\d+\.\d+\.\d+$/.test(newVersion)) {
+// Validate semver format (with optional pre-release suffix like -rc.1, -beta.2)
+if (!/^\d+\.\d+\.\d+(-[a-zA-Z0-9.-]+)?$/.test(newVersion)) {
   console.error(`Invalid version: ${newVersion}`);
   process.exit(1);
 }

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skima-server",
-  "version": "1.3.5",
+  "version": "1.4.0-rc.1",
   "private": true,
   "type": "module",
   "bin": "src/index.js",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skima"
-version = "1.3.5"
+version = "1.4.0-rc.1"
 description = "Skima - People Development Platform"
 authors = ["DLSLabs"]
 edition = "2024"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Skima",
-  "version": "1.3.5",
+  "version": "1.4.0-rc.1",
   "identifier": "com.dlslabs.skima",
   "build": {
     "beforeDevCommand": "npm run dev:client",


### PR DESCRIPTION
Sync the version-bump commit to main. The v1.4.0-rc.1 tag already points at this commit (CI is running) — this PR just brings main in line so future tags inherit the bumped version.

Also relaxes the bump-version.js semver regex to accept pre-release suffixes (-rc.1, -beta.2, etc.) so future RC tagging is a single command.