### PR TITLE
fix(updater): User-Agent header for Windows

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "skima",
   "private": true,
-  "version": "1.4.0-rc.1",
+  "version": "1.4.0-rc.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/client/src/contexts/UpdateContext.jsx
+++ b/client/src/contexts/UpdateContext.jsx
@@ -16,6 +16,19 @@ const STORAGE_KEYS = {
 const SNOOZE_MS = 24 * 60 * 60 * 1000; // 24h
 const AUTO_CHECK_DELAY_MS = 4000;
 
+// GitHub's storage CDN (objects.githubusercontent.com) hangs on requests
+// without a User-Agent. reqwest (used by the Tauri updater) sends none by
+// default, so the client waits ~60s before reqwest aborts and the user
+// sees a generic "error sending request". Setting an explicit UA fixes
+// it. The timeout is a safety net for genuine network unreachability.
+const UPDATE_CHECK_OPTIONS = {
+  timeout: 30_000,
+  headers: {
+    'User-Agent': 'Skima-Updater',
+    Accept: 'application/octet-stream',
+  },
+};
+
 const isTauri = () => typeof window !== 'undefined' && !!window.__TAURI_INTERNALS__;
 
 const getAutoCheckPref = () => localStorage.getItem(STORAGE_KEYS.AUTO_CHECK) !== 'false';
@@ -71,7 +84,7 @@ export function UpdateProvider({ children }) {
     setState('checking');
     setError(null);
     try {
-      const result = await checkForUpdate();
+      const result = await checkForUpdate(UPDATE_CHECK_OPTIONS);
       localStorage.setItem(STORAGE_KEYS.LAST_CHECKED, String(Date.now()));
 
       if (!result) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skima",
-  "version": "1.4.0-rc.1",
+  "version": "1.4.0-rc.2",
   "private": true,
   "description": "Skima - People Development Platform",
   "scripts": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skima-server",
-  "version": "1.4.0-rc.1",
+  "version": "1.4.0-rc.2",
   "private": true,
   "type": "module",
   "bin": "src/index.js",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skima"
-version = "1.4.0-rc.1"
+version = "1.4.0-rc.2"
 description = "Skima - People Development Platform"
 authors = ["DLSLabs"]
 edition = "2024"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Skima",
-  "version": "1.4.0-rc.1",
+  "version": "1.4.0-rc.2",
   "identifier": "com.dlslabs.skima",
   "build": {
     "beforeDevCommand": "npm run dev:client",


### PR DESCRIPTION
Tauri updater hangs ~60s on Windows because reqwest sends no User-Agent and GitHub's CDN rejects it. Adds explicit UA + Accept + 30s timeout. Bumps to v1.4.0-rc.2.