### PR TITLE
chore: bump to v1.4.0-rc.6

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "skima",
   "private": true,
-  "version": "1.4.0-rc.5",
+  "version": "1.4.0-rc.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skima",
-  "version": "1.4.0-rc.5",
+  "version": "1.4.0-rc.6",
   "private": true,
   "description": "Skima - People Development Platform",
   "scripts": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skima-server",
-  "version": "1.4.0-rc.5",
+  "version": "1.4.0-rc.6",
   "private": true,
   "type": "module",
   "bin": "src/index.js",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skima"
-version = "1.4.0-rc.5"
+version = "1.4.0-rc.6"
 description = "Skima - People Development Platform"
 authors = ["DLSLabs"]
 edition = "2024"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Skima",
-  "version": "1.4.0-rc.5",
+  "version": "1.4.0-rc.6",
   "identifier": "com.dlslabs.skima",
   "build": {
     "beforeDevCommand": "npm run dev:client",


### PR DESCRIPTION
Trivial bump to validate the full auto-update flow rc.5 → rc.6 with the sidecar fix.