### PR TITLE
release: v1.4.0 — auto-updater

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "skima",
   "private": true,
-  "version": "1.4.0-rc.6",
+  "version": "1.4.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skima",
-  "version": "1.4.0-rc.6",
+  "version": "1.4.0",
   "private": true,
   "description": "Skima - People Development Platform",
   "scripts": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skima-server",
-  "version": "1.4.0-rc.6",
+  "version": "1.4.0",
   "private": true,
   "type": "module",
   "bin": "src/index.js",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skima"
-version = "1.4.0-rc.6"
+version = "1.4.0"
 description = "Skima - People Development Platform"
 authors = ["DLSLabs"]
 edition = "2024"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Skima",
-  "version": "1.4.0-rc.6",
+  "version": "1.4.0",
   "identifier": "com.dlslabs.skima",
   "build": {
     "beforeDevCommand": "npm run dev:client",


### PR DESCRIPTION
First self-updating release of Skima. After v1.4.0, users receive future versions automatically (with their consent) via the in-app updater modal. No more manual reinstalls.

## Closes
Closes #39 (auto-updater feature)
Closes #41 (v1.4.0 meta — see re-numbering note)

## Re-numbering note (#41 was the meta)

#41 originally tracked v1.4.0 = auto-updater + IDP visibility. During execution we split:
- **v1.4.0 (this release):** auto-updater only — what #41 captured the design for
- **v1.4.1:** IDP visibility (#36, #37, #38) — split into its own release
- **v1.4.x:** Windows code signing (#40) — gated on Microsoft Trusted Signing approval

The meta closes because v1.4.0 ships as scoped. Remaining work continues in #36/#37/#38/#40 as standalone issues.

## RC summary

The auto-updater took 6 release candidates to validate end-to-end on Windows:

| RC | Fix |
|---|---|
| rc.1 | initial cut (broken — version not bumped) |
| rc.2 | User-Agent header for GitHub CDN |
| rc.3 | retry with backoff + Schannel TLS for transient pre-TCP failures |
| rc.4 | trivial bump to validate update modal flow |
| rc.5 | kill sidecar BEFORE installer to release file lock on skima-server.exe |
| rc.6 | trivial bump to validate full rc.5 → rc.6 auto-update end-to-end |

All 6 RC releases and tags deleted. CI will publish v1.4.0 as the first clean public release.

## What's in v1.4.0

### Auto-updater
- @tauri-apps/plugin-updater + plugin-process integrated
- Modal with consent (Update now / Remind me later 24h / Skip this version)
- Manual check button in Settings → About
- Toggle to disable auto-checks
- Cryptographically signed binaries
- Windows + macOS + Linux AppImage supported; .deb / .rpm shows manual-update CTA
- Retry with backoff for transient pre-TCP failures
- Schannel TLS on Windows
- Sidecar kill before installer

### Out of scope (next releases)
- IDP visibility (#36, #37, #38) → v1.4.1
- Windows code signing (#40) → v1.4.x