### PR TITLE
fix(macos): ad-hoc signing for .app bundle (v1.4.1 hotfix)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,18 +161,13 @@ jobs:
           # and existing v1.4.0+ clients will refuse the update.
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
-          # macOS code signing + Apple notarization. These secrets only have
-          # effect on the macOS runner; tauri-action ignores them on Win/Linux.
-          # Without them the .dmg/.app is unsigned and Gatekeeper hard-blocks it
-          # on first launch with "Apple could not verify Skima". Setting all 6
-          # makes tauri-action sign with Developer ID + submit to Apple's
-          # notarization service automatically. See issue #54.
-          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
-          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          # NOTE on macOS code signing: Apple Developer Program enrollment is
+          # deferred (see issue #54). The .app bundle is built with ad-hoc
+          # signing (signingIdentity: "-" in tauri.macos.conf.json) so the
+          # bundler succeeds without a real cert. Result: users still see
+          # Gatekeeper warning on first launch and apply the documented
+          # workaround. When Apple secrets are added, remove the "-" identity
+          # and add the 6 APPLE_* env vars below the GITHUB_TOKEN line.
         with:
           tagName: ${{ github.ref_name }}
           releaseName: 'Skima ${{ github.ref_name }}'

--- a/src-tauri/tauri.macos.conf.json
+++ b/src-tauri/tauri.macos.conf.json
@@ -1,5 +1,8 @@
 {
   "bundle": {
-    "targets": ["dmg", "app"]
+    "targets": ["dmg", "app"],
+    "macOS": {
+      "signingIdentity": "-"
+    }
   }
 }


### PR DESCRIPTION
First v1.4.1 build failed in macOS bundle phase: `failed codesign application: failed to import keychain certificate`.

Root cause: adding `"app"` to bundle.targets (#51 fix) makes Tauri try to codesign the .app. Without Apple Developer enrollment (deferred per #54), Tauri tries the default keychain and explodes. The empty `APPLE_*` env vars on the workflow also confused tauri-action's signing detection.

## Fixes

- `tauri.macos.conf.json`: explicit `signingIdentity: "-"` (ad-hoc signing). The .app bundle gets a self-signed identity for Tauri's bundler. macOS Gatekeeper still treats it as untrusted on first launch — same UX as before (workaround docs in README).
- `release.yml`: remove the empty `APPLE_*` env var block. Documented in a comment how to re-enable when Apple cert is enrolled.

## Status before tag

The previous v1.4.1 tag + release (with partial Linux+Windows assets) have been deleted from GitHub. Re-tagging from main after this merges.

## Tests
- `cargo check` clean
- 898 client + 171 server + 8 scripts tests passing (no logic changes)