### PR TITLE
v1.4.2 — Launch Hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ Starting with **v1.4.0**, Skima checks for new releases on startup and lets you 
 
 Updates are cryptographically signed; Skima refuses any binary that doesn't match the publisher signature.
 
+**Desktop only:** the in-app updater ships with the desktop app. The web/[Docker](#docker) deployment and the online demo run in a browser, so they never auto-update — a self-hosted instance is updated by pulling the new image (see below).
+
 **Linux note:** auto-update works for the **AppImage** build. If you installed via `.deb` or `.rpm`, your system package manager owns the install path so Skima can't replace itself in-place — Skima will detect this and prompt you to download the latest release from GitHub manually. Switch to the AppImage build if you want fully automatic updates.
 
 ### Docker
@@ -153,6 +155,13 @@ docker run -d -p 3000:3001 -v skima-data:/app/data ghcr.io/henfrydls/skima:lates
 ```
 
 Open `http://localhost:3000` in your browser. Data persists in a Docker volume.
+
+**Updating a self-hosted instance:** pull the new image and restart — the in-app updater doesn't apply to the web/Docker deployment.
+
+```bash
+docker pull ghcr.io/henfrydls/skima:latest
+docker compose up -d   # or re-run your docker run with the new image
+```
 
 To run with demo data pre-loaded:
 

--- a/client/src/components/common/UpdateModal.jsx
+++ b/client/src/components/common/UpdateModal.jsx
@@ -66,6 +66,23 @@ export default function UpdateModal() {
           </>
         )}
 
+        {state === 'preparing' && (
+          <>
+            <div className="px-6 py-4 border-b border-gray-100">
+              <h2 id="update-modal-title" className="text-lg font-semibold text-gray-900">
+                Preparing update...
+              </h2>
+              <p className="text-xs text-gray-500 mt-0.5">Skima {updateInfo?.version}</p>
+            </div>
+            <div className="px-6 py-6 flex flex-col items-center text-center gap-3">
+              <Loader2 size={32} className="text-primary animate-spin" />
+              <p className="text-sm text-gray-600">
+                Getting things ready — this only takes a moment.
+              </p>
+            </div>
+          </>
+        )}
+
         {state === 'downloading' && (
           <>
             <div className="px-6 py-4 border-b border-gray-100">

--- a/client/src/components/common/__tests__/UpdateModal.test.jsx
+++ b/client/src/components/common/__tests__/UpdateModal.test.jsx
@@ -71,6 +71,20 @@ describe('UpdateModal', () => {
     });
   });
 
+  describe('preparing state', () => {
+    it('shows a preparing message (#52)', () => {
+      mockContext.state = 'preparing';
+      render(<UpdateModal />);
+      expect(screen.getByText(/Preparing update/i)).toBeInTheDocument();
+    });
+
+    it('does not render the "Update now" button while preparing', () => {
+      mockContext.state = 'preparing';
+      render(<UpdateModal />);
+      expect(screen.queryByRole('button', { name: /Update now/i })).not.toBeInTheDocument();
+    });
+  });
+
   describe('downloading state', () => {
     it('shows progress information', () => {
       mockContext.state = 'downloading';

--- a/client/src/components/development/GoalAccordion.jsx
+++ b/client/src/components/development/GoalAccordion.jsx
@@ -55,10 +55,10 @@ export default function GoalAccordion({ goal, onEdit, onDelete, onAddAction, onU
         {goal.skill && (
           <span
             className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs bg-primary/10 text-primary font-medium"
-            title={`Linked skill: ${goal.skill.name}${goal.targetLevel != null ? ` · target level ${goal.targetLevel}` : ''}`}
+            title={`Linked skill: ${goal.skill.nombre}${goal.targetLevel != null ? ` · target level ${goal.targetLevel}` : ''}`}
           >
             <Target size={10} />
-            {goal.skill.name}
+            {goal.skill.nombre}
           </span>
         )}
 

--- a/client/src/components/development/GoalAccordion.jsx
+++ b/client/src/components/development/GoalAccordion.jsx
@@ -1,12 +1,7 @@
 import { useState } from 'react';
 import { ChevronDown, ChevronRight, Plus, Trash2, Edit2, Target, CheckCircle2 } from 'lucide-react';
 import ActionRow from './ActionRow';
-
-const PRIORITY_COLORS = {
-  high: 'bg-critical',
-  medium: 'bg-warning',
-  low: 'bg-gray-300',
-};
+import { getPriorityMeta } from '../../lib/goalPriority';
 
 /**
  * GoalAccordion - Expandable goal card with nested actions
@@ -20,6 +15,7 @@ export default function GoalAccordion({ goal, onEdit, onDelete, onAddAction, onU
   const countableActions = actions.filter(a => a.status !== 'skipped');
   const completedActions = countableActions.filter(a => a.status === 'completed').length;
   const progress = countableActions.length > 0 ? (completedActions / countableActions.length) * 100 : 0;
+  const priority = getPriorityMeta(goal.priority);
 
   const formatDate = (dateStr) => {
     if (!dateStr) return null;
@@ -44,9 +40,9 @@ export default function GoalAccordion({ goal, onEdit, onDelete, onAddAction, onU
 
         {/* Priority dot */}
         <span
-          className={`w-2 h-2 rounded-full flex-shrink-0 ${PRIORITY_COLORS[goal.priority] || PRIORITY_COLORS.medium}`}
-          title={`${goal.priority || 'medium'} priority`}
-          aria-label={`Priority: ${goal.priority === 'high' ? 'high' : goal.priority === 'low' ? 'low' : 'medium'}`}
+          className={`w-2 h-2 rounded-full flex-shrink-0 ${priority.color}`}
+          title={`${priority.label} priority`}
+          aria-label={`Priority: ${priority.label}`}
           role="img"
         />
 
@@ -55,11 +51,24 @@ export default function GoalAccordion({ goal, onEdit, onDelete, onAddAction, onU
           {goal.title}
         </span>
 
-        {/* Skill badge */}
+        {/* Skill badge — tooltip surfaces the linked skill + target on hover */}
         {goal.skill && (
-          <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs bg-primary/10 text-primary font-medium">
+          <span
+            className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs bg-primary/10 text-primary font-medium"
+            title={`Linked skill: ${goal.skill.name}${goal.targetLevel != null ? ` · target level ${goal.targetLevel}` : ''}`}
+          >
             <Target size={10} />
             {goal.skill.name}
+          </span>
+        )}
+
+        {/* Target level badge (#38) */}
+        {goal.targetLevel != null && (
+          <span
+            className="inline-flex items-center px-2 py-0.5 rounded-full text-xs bg-gray-100 text-gray-600 font-medium flex-shrink-0"
+            title={`Target level ${goal.targetLevel}`}
+          >
+            Lvl {goal.targetLevel}
           </span>
         )}
 

--- a/client/src/components/development/__tests__/GoalAccordion.test.jsx
+++ b/client/src/components/development/__tests__/GoalAccordion.test.jsx
@@ -70,6 +70,35 @@ describe('GoalAccordion', () => {
     expect(dot).toBeInTheDocument();
   });
 
+  // #36: priority arrives from the API as an integer (1=high, 2=medium, 3=low).
+  it('maps integer priority 1 to the high color', () => {
+    const { container } = renderGoal({ goal: { ...mockGoal, priority: 1 } });
+    expect(container.querySelector('.bg-critical')).toBeInTheDocument();
+  });
+
+  it('maps integer priority 3 to the low color', () => {
+    const { container } = renderGoal({ goal: { ...mockGoal, priority: 3 } });
+    expect(container.querySelector('.bg-gray-300')).toBeInTheDocument();
+  });
+
+  // #38: the goal's target level is saved but was never displayed.
+  it('surfaces the target level when present', () => {
+    renderGoal({ goal: { ...mockGoal, targetLevel: 4 } });
+    expect(screen.getByText(/Lvl 4/i)).toBeInTheDocument();
+  });
+
+  it('does not show a target-level badge when targetLevel is null', () => {
+    renderGoal({ goal: { ...mockGoal, targetLevel: null } });
+    expect(screen.queryByText(/Lvl/i)).not.toBeInTheDocument();
+  });
+
+  // #37: linked skill badge exposes context on hover via a title tooltip.
+  it('gives the linked skill badge a descriptive tooltip', () => {
+    renderGoal({ goal: { ...mockGoal, skill: { id: 1, name: 'React' }, targetLevel: 4 } });
+    const badge = screen.getByText('React').closest('span');
+    expect(badge).toHaveAttribute('title', expect.stringContaining('React'));
+  });
+
   it('shows action count (completed/total)', () => {
     renderGoal();
     // 1 completed out of 2

--- a/client/src/components/development/__tests__/GoalAccordion.test.jsx
+++ b/client/src/components/development/__tests__/GoalAccordion.test.jsx
@@ -21,7 +21,7 @@ const mockGoal = {
   id: 1,
   title: 'Improve React Testing',
   description: 'Reach level 4 in testing',
-  skill: { id: 1, name: 'React' },
+  skill: { id: 1, nombre: 'React' },
   priority: 'high',
   status: 'in_progress',
   actions: [
@@ -94,7 +94,7 @@ describe('GoalAccordion', () => {
 
   // #37: linked skill badge exposes context on hover via a title tooltip.
   it('gives the linked skill badge a descriptive tooltip', () => {
-    renderGoal({ goal: { ...mockGoal, skill: { id: 1, name: 'React' }, targetLevel: 4 } });
+    renderGoal({ goal: { ...mockGoal, skill: { id: 1, nombre: 'React' }, targetLevel: 4 } });
     const badge = screen.getByText('React').closest('span');
     expect(badge).toHaveAttribute('title', expect.stringContaining('React'));
   });

--- a/client/src/components/settings/DevelopmentTab.jsx
+++ b/client/src/components/settings/DevelopmentTab.jsx
@@ -11,7 +11,8 @@ import LoginModal from '../auth/LoginModal';
 import PlanFormModal from './DevelopmentPlanFormModal';
 import GoalFormModal from './DevelopmentGoalFormModal';
 import ActionFormModal from './DevelopmentActionFormModal';
-import { PLAN_STATUS_BADGES, ACTION_TYPE_BADGES, PRIORITY_COLORS } from '../../lib/developmentConstants';
+import { PLAN_STATUS_BADGES, ACTION_TYPE_BADGES } from '../../lib/developmentConstants';
+import { getPriorityMeta } from '../../lib/goalPriority';
 
 const ACTION_STATUS_OPTIONS = [
   { value: 'not_started', bg: 'bg-gray-100', text: 'text-gray-600', label: 'Not Started' },
@@ -712,7 +713,7 @@ export default function DevelopmentTab({ isActive }) {
                           const countableActions = actions.filter(a => a.status !== 'skipped');
                           const completedActions = countableActions.filter(a => a.status === 'completed').length;
                           const goalProgress = countableActions.length > 0 ? Math.round((completedActions / countableActions.length) * 100) : 0;
-                          const priorityColor = PRIORITY_COLORS[goal.priority] || PRIORITY_COLORS.medium;
+                          const priorityMeta = getPriorityMeta(goal.priority);
 
                           return (
                             <div key={goal.id} className="bg-white border border-gray-200 rounded-lg overflow-hidden">
@@ -731,8 +732,8 @@ export default function DevelopmentTab({ isActive }) {
 
                                 {/* Priority dot */}
                                 <span
-                                  className={`w-2 h-2 rounded-full flex-shrink-0 ${priorityColor}`}
-                                  title={`${goal.priority || 'medium'} priority`}
+                                  className={`w-2 h-2 rounded-full flex-shrink-0 ${priorityMeta.color}`}
+                                  title={`${priorityMeta.label} priority`}
                                 />
 
                                 {/* Title */}
@@ -740,11 +741,24 @@ export default function DevelopmentTab({ isActive }) {
                                   {goal.title}
                                 </span>
 
-                                {/* Skill badge */}
+                                {/* Skill badge — tooltip surfaces the linked skill + target on hover */}
                                 {goal.skill && (
-                                  <span className="hidden sm:inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs bg-primary/10 text-primary font-medium">
+                                  <span
+                                    className="hidden sm:inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs bg-primary/10 text-primary font-medium"
+                                    title={`Linked skill: ${goal.skill.nombre}${goal.targetLevel != null ? ` · target level ${goal.targetLevel}` : ''}`}
+                                  >
                                     <Target size={10} />
                                     {goal.skill.nombre}
+                                  </span>
+                                )}
+
+                                {/* Target level badge (#38) */}
+                                {goal.targetLevel != null && (
+                                  <span
+                                    className="hidden sm:inline-flex items-center px-2 py-0.5 rounded-full text-xs bg-gray-100 text-gray-600 font-medium flex-shrink-0"
+                                    title={`Target level ${goal.targetLevel}`}
+                                  >
+                                    Lvl {goal.targetLevel}
                                   </span>
                                 )}
 

--- a/client/src/contexts/UpdateContext.jsx
+++ b/client/src/contexts/UpdateContext.jsx
@@ -190,9 +190,12 @@ export function UpdateProvider({ children }) {
   const installNow = useCallback(async () => {
     const handle = updateHandleRef.current;
     if (!handle) return;
-    setState('downloading');
     setError(null);
     setProgress({ downloaded: 0, total: 0 });
+    // Show 'preparing' while the sidecar shuts down. prepare_for_update takes
+    // ~1.5s on Windows to release the file lock; without a distinct state the
+    // user stares at a 'Downloading... 0%' bar that isn't moving yet (#52).
+    setState('preparing');
 
     try {
       // Kill the sidecar BEFORE the installer runs. If we don't, Windows
@@ -207,6 +210,7 @@ export function UpdateProvider({ children }) {
         console.warn('[updater] prepare_for_update failed:', e);
       }
 
+      setState('downloading');
       let total = 0;
       await handle.downloadAndInstall((event) => {
         // Tauri's progress event shape:
@@ -261,6 +265,10 @@ export function UpdateProvider({ children }) {
   // the modal appears over the welcome screen on a fresh first launch.
   useEffect(() => {
     if (!isTauri()) return;
+    // In `tauri:dev` the updater hits the real GitHub release, so the modal
+    // would pop over the dev session. Skip auto-check there; the manual
+    // "Check for updates" button in Settings still works.
+    if (import.meta.env.MODE === 'development') return;
     if (!getAutoCheckPref()) return;
     if (!isSetup) return;
     const t = setTimeout(() => {
@@ -269,7 +277,7 @@ export function UpdateProvider({ children }) {
     return () => clearTimeout(t);
   }, [checkNow, isSetup]);
 
-  const showModal = state === 'available' || state === 'downloading' || state === 'installing' || state === 'error' || state === 'manual-only';
+  const showModal = state === 'available' || state === 'preparing' || state === 'downloading' || state === 'installing' || state === 'error' || state === 'manual-only';
 
   const value = {
     state,

--- a/client/src/contexts/__tests__/UpdateContext.test.jsx
+++ b/client/src/contexts/__tests__/UpdateContext.test.jsx
@@ -6,6 +6,7 @@ import { UpdateProvider, useUpdate } from '../UpdateContext';
 const mockCheck = vi.fn();
 const mockDownloadAndInstall = vi.fn();
 const mockRelaunch = vi.fn();
+const mockInvoke = vi.fn();
 
 vi.mock('@tauri-apps/plugin-updater', () => ({
   check: () => mockCheck(),
@@ -13,6 +14,10 @@ vi.mock('@tauri-apps/plugin-updater', () => ({
 
 vi.mock('@tauri-apps/plugin-process', () => ({
   relaunch: () => mockRelaunch(),
+}));
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: (...args) => mockInvoke(...args),
 }));
 
 vi.mock('../../hooks/useAppVersion', () => ({
@@ -55,6 +60,8 @@ describe('UpdateContext', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     localStorage.clear();
+    // Default: prepare_for_update resolves immediately (sidecar shut down ok)
+    mockInvoke.mockResolvedValue(undefined);
     // Default: pretend we're in Tauri so auto-check would normally run
     window.__TAURI_INTERNALS__ = {};
     // Default: setup is complete
@@ -63,6 +70,7 @@ describe('UpdateContext', () => {
 
   afterEach(() => {
     delete window.__TAURI_INTERNALS__;
+    vi.unstubAllEnvs();
     vi.useRealTimers();
   });
 
@@ -200,6 +208,16 @@ describe('UpdateContext', () => {
       expect(mockCheck).not.toHaveBeenCalled();
     });
 
+    // DEV gate: `npm run tauri:dev` (MODE=development) hits the real GitHub
+    // release, so don't auto-check there — the manual button still works.
+    it('does not run in dev mode (tauri:dev)', async () => {
+      vi.stubEnv('MODE', 'development');
+      vi.useFakeTimers();
+      renderWithProvider();
+      await act(async () => { await vi.advanceTimersByTimeAsync(5000); });
+      expect(mockCheck).not.toHaveBeenCalled();
+    });
+
     it('runs after 4s when in Tauri and autoCheck enabled (default)', async () => {
       mockCheck.mockResolvedValue(null);
       vi.useFakeTimers();
@@ -286,6 +304,30 @@ describe('UpdateContext', () => {
   });
 
   describe('installNow', () => {
+    it('passes through a "preparing" state before downloading (#52)', async () => {
+      // Hold prepare_for_update pending so we can observe the preparing state.
+      let resolvePrepare;
+      mockInvoke.mockReturnValueOnce(new Promise((res) => { resolvePrepare = res; }));
+      mockDownloadAndInstall.mockResolvedValue(undefined);
+      mockRelaunch.mockResolvedValue(undefined);
+      mockCheck.mockResolvedValue({
+        version: '1.5.0',
+        body: '',
+        downloadAndInstall: mockDownloadAndInstall,
+      });
+      renderWithProvider();
+
+      await act(async () => { screen.getByTestId('check').click(); });
+      await waitFor(() => expect(screen.getByTestId('state').textContent).toBe('available'));
+
+      await act(async () => { screen.getByTestId('install').click(); });
+      // prepare_for_update still pending -> we are 'preparing', not 'downloading'
+      expect(screen.getByTestId('state').textContent).toBe('preparing');
+
+      await act(async () => { resolvePrepare(); });
+      await waitFor(() => expect(mockRelaunch).toHaveBeenCalled());
+    });
+
     it('calls downloadAndInstall then relaunch', async () => {
       mockDownloadAndInstall.mockResolvedValue(undefined);
       mockRelaunch.mockResolvedValue(undefined);

--- a/client/src/lib/__tests__/goalPriority.test.js
+++ b/client/src/lib/__tests__/goalPriority.test.js
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { getPriorityMeta } from '../goalPriority';
+
+describe('getPriorityMeta', () => {
+  // The API stores priority as an integer (1=high, 2=medium, 3=low). This is
+  // the case that was previously broken: a string-keyed color map never
+  // matched the integer, so every goal rendered as medium (#36).
+  it('maps integer 1 to high', () => {
+    expect(getPriorityMeta(1)).toMatchObject({ key: 'high', color: 'bg-critical' });
+  });
+
+  it('maps integer 2 to medium', () => {
+    expect(getPriorityMeta(2)).toMatchObject({ key: 'medium', color: 'bg-warning' });
+  });
+
+  it('maps integer 3 to low', () => {
+    expect(getPriorityMeta(3)).toMatchObject({ key: 'low', color: 'bg-gray-300' });
+  });
+
+  // Legacy/string values are tolerated for backward compatibility.
+  it('maps string "high" to high', () => {
+    expect(getPriorityMeta('high')).toMatchObject({ key: 'high' });
+  });
+
+  it('maps string "low" to low', () => {
+    expect(getPriorityMeta('low')).toMatchObject({ key: 'low' });
+  });
+
+  it('falls back to medium for null/unknown values', () => {
+    expect(getPriorityMeta(null)).toMatchObject({ key: 'medium' });
+    expect(getPriorityMeta(undefined)).toMatchObject({ key: 'medium' });
+    expect(getPriorityMeta(99)).toMatchObject({ key: 'medium' });
+  });
+
+  it('exposes a human label', () => {
+    expect(getPriorityMeta(1).label).toBe('High');
+    expect(getPriorityMeta(3).label).toBe('Low');
+  });
+});

--- a/client/src/lib/goalPriority.js
+++ b/client/src/lib/goalPriority.js
@@ -1,0 +1,17 @@
+// Development-goal priority display metadata.
+//
+// Priority is persisted as an integer (1=high, 2=medium, 3=low). Older/string
+// values ('high'|'medium'|'low') are tolerated so any cached or legacy payload
+// still renders correctly.
+
+export const PRIORITY_META = {
+  high: { key: 'high', color: 'bg-critical', label: 'High' },
+  medium: { key: 'medium', color: 'bg-warning', label: 'Medium' },
+  low: { key: 'low', color: 'bg-gray-300', label: 'Low' },
+};
+
+export function getPriorityMeta(priority) {
+  if (priority === 1 || priority === 'high') return PRIORITY_META.high;
+  if (priority === 3 || priority === 'low') return PRIORITY_META.low;
+  return PRIORITY_META.medium;
+}

--- a/server/src/__tests__/cors-proxy.test.js
+++ b/server/src/__tests__/cors-proxy.test.js
@@ -1,0 +1,56 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import request from 'supertest';
+import { createApp } from '../index.js';
+
+// CORS is permissive by default (desktop Tauri webview + local dev rely on
+// it) and locks down to an allowlist only when ALLOWED_ORIGINS is set, which
+// the hosted demo / self-host deployments do.
+describe('CORS configuration', () => {
+  afterEach(() => {
+    delete process.env.ALLOWED_ORIGINS;
+  });
+
+  it('allows any origin by default (permissive for desktop / dev)', async () => {
+    const app = createApp();
+    const res = await request(app).get('/api/config').set('Origin', 'http://anything.example');
+    expect(res.headers['access-control-allow-origin']).toBe('*');
+  });
+
+  it('reflects an allowlisted origin when ALLOWED_ORIGINS is set', async () => {
+    process.env.ALLOWED_ORIGINS = 'https://skima.henfrydls.com';
+    const app = createApp();
+    const res = await request(app)
+      .get('/api/config')
+      .set('Origin', 'https://skima.henfrydls.com');
+    expect(res.headers['access-control-allow-origin']).toBe('https://skima.henfrydls.com');
+  });
+
+  it('omits the CORS header for a non-allowlisted origin', async () => {
+    process.env.ALLOWED_ORIGINS = 'https://skima.henfrydls.com';
+    const app = createApp();
+    const res = await request(app)
+      .get('/api/config')
+      .set('Origin', 'https://evil.example');
+    expect(res.headers['access-control-allow-origin']).toBeUndefined();
+  });
+});
+
+// trust proxy must be enabled behind Cloudflare/Nginx so the login rate
+// limiter buckets by the real client IP, not the proxy's. Off by default so a
+// directly-exposed instance can't be IP-spoofed via X-Forwarded-For.
+describe('trust proxy configuration', () => {
+  afterEach(() => {
+    delete process.env.TRUST_PROXY;
+  });
+
+  it('does not trust proxy headers by default', () => {
+    const app = createApp();
+    expect(app.get('trust proxy')).toBe(false);
+  });
+
+  it('trusts the first proxy hop when TRUST_PROXY is set', () => {
+    process.env.TRUST_PROXY = '1';
+    const app = createApp();
+    expect(app.get('trust proxy')).toBe(1);
+  });
+});

--- a/server/src/__tests__/demo-middleware.test.js
+++ b/server/src/__tests__/demo-middleware.test.js
@@ -1,12 +1,14 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import request from 'supertest';
 import { createApp, prisma } from '../index.js';
+import { resetSeedRateLimiter } from '../routes/demo.js';
 
 describe('Demo Mode Middleware', () => {
   let app;
 
   beforeEach(async () => {
     process.env.DEMO_MODE = 'true';
+    resetSeedRateLimiter();
     app = createApp();
 
     await prisma.assessment.deleteMany();
@@ -230,6 +232,32 @@ describe('Demo Mode Middleware', () => {
 
       expect(res.status).toBe(200);
       expect(res.body.isOnlineDemo).toBe(false);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Group 5: seed-demo is rate-limited per IP in demo mode (DoS mitigation)
+  // ---------------------------------------------------------------------------
+  describe('seed-demo rate limit (DEMO_MODE)', () => {
+    it('429s after exceeding the per-IP reseed limit', async () => {
+      // SEED_MAX = 3 allowed within the window; the 4th is throttled.
+      for (let i = 0; i < 3; i++) {
+        const ok = await request(app).post('/api/seed-demo');
+        expect(ok.status).not.toBe(429);
+      }
+      const blocked = await request(app).post('/api/seed-demo');
+      expect(blocked.status).toBe(429);
+      expect(blocked.body.error).toBe('RATE_LIMITED');
+    });
+
+    it('does not rate-limit seed-demo when DEMO_MODE is unset', async () => {
+      delete process.env.DEMO_MODE;
+      resetSeedRateLimiter();
+      const freshApp = createApp();
+      for (let i = 0; i < 4; i++) {
+        const res = await request(freshApp).post('/api/seed-demo');
+        expect(res.status).not.toBe(429);
+      }
     });
   });
 });

--- a/server/src/__tests__/demo-middleware.test.js
+++ b/server/src/__tests__/demo-middleware.test.js
@@ -99,6 +99,44 @@ describe('Demo Mode Middleware', () => {
       expect(res.status).toBe(403);
       expect(res.body.error).toBe('DEMO_MODE');
     });
+
+    // Previously-unprotected mutators — the allowlist model now blocks them so
+    // the shared public demo stays read-only.
+    it('POST /api/collaborators returns 403', async () => {
+      const res = await request(app)
+        .post('/api/collaborators')
+        .send({ nombre: 'Test', rol: 'Dev', area: 'Eng' });
+
+      expect(res.status).toBe(403);
+      expect(res.body.error).toBe('DEMO_MODE');
+    });
+
+    it('POST /api/evaluations returns 403', async () => {
+      const res = await request(app)
+        .post('/api/evaluations')
+        .send({ collaboratorId: 1 });
+
+      expect(res.status).toBe(403);
+      expect(res.body.error).toBe('DEMO_MODE');
+    });
+
+    it('PUT /api/collaborators/1/skills returns 403', async () => {
+      const res = await request(app)
+        .put('/api/collaborators/1/skills')
+        .send({ 1: { nivel: 3, frecuencia: 'D' } });
+
+      expect(res.status).toBe(403);
+      expect(res.body.error).toBe('DEMO_MODE');
+    });
+
+    it('PUT /api/role-profiles/Developer returns 403', async () => {
+      const res = await request(app)
+        .put('/api/role-profiles/Developer')
+        .send({ 1: 'C' });
+
+      expect(res.status).toBe(403);
+      expect(res.body.error).toBe('DEMO_MODE');
+    });
   });
 
   // ---------------------------------------------------------------------------
@@ -121,14 +159,6 @@ describe('Demo Mode Middleware', () => {
 
     it('GET /api/data is not blocked', async () => {
       const res = await request(app).get('/api/data');
-
-      expect(res.status).not.toBe(403);
-    });
-
-    it('POST /api/collaborators is not blocked', async () => {
-      const res = await request(app)
-        .post('/api/collaborators')
-        .send({ nombre: 'Test', rol: 'Dev', area: 'Eng' });
 
       expect(res.status).not.toBe(403);
     });

--- a/server/src/__tests__/development.test.js
+++ b/server/src/__tests__/development.test.js
@@ -153,6 +153,37 @@ describe('Development Plans API', () => {
       expect(res.status).toBe(404);
     });
 
+    // #37: the linked skill must be included on goals, otherwise the skill
+    // badge + tooltip in the UI never renders (goal.skill would be undefined).
+    it('GET /api/development-plans/:id — includes the linked skill on goals', async () => {
+      const plan = await prisma.developmentPlan.create({
+        data: { collaboratorId: collaborator.id, title: 'Plan with skill' }
+      });
+      await prisma.developmentGoal.create({
+        data: { planId: plan.id, title: 'Master React', skillId: skill.id }
+      });
+
+      const res = await request(app).get(`/api/development-plans/${plan.id}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.goals[0].skill).toBeTruthy();
+      expect(res.body.goals[0].skill.nombre).toBe('React');
+    });
+
+    it('GET /api/development-plans — includes the linked skill on goals', async () => {
+      const plan = await prisma.developmentPlan.create({
+        data: { collaboratorId: collaborator.id, title: 'List skill check' }
+      });
+      await prisma.developmentGoal.create({
+        data: { planId: plan.id, title: 'Master React', skillId: skill.id }
+      });
+
+      const res = await request(app).get('/api/development-plans');
+      expect(res.status).toBe(200);
+      const found = res.body.find((p) => p.title === 'List skill check');
+      expect(found.goals[0].skill.nombre).toBe('React');
+    });
+
     it('PUT /api/development-plans/:id — updates plan fields', async () => {
       const plan = await prisma.developmentPlan.create({
         data: { collaboratorId: collaborator.id, title: 'Original' }

--- a/server/src/__tests__/evaluations.test.js
+++ b/server/src/__tests__/evaluations.test.js
@@ -1,0 +1,250 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import request from 'supertest';
+import { createApp, prisma } from '../index.js';
+
+// Characterization tests for the evaluation endpoints. These lock in the
+// CURRENT correct behavior of the highest-risk write paths in index.js
+// (PUT /collaborators/:id/skills, POST/GET/DELETE /evaluations) so that the
+// Prisma 6->7 migration and the demo-mode hardening can't silently regress
+// them. Auth is open in tests (no admin password configured).
+
+describe('Evaluation endpoints', () => {
+  let app;
+  let collab;
+
+  beforeEach(async () => {
+    app = createApp();
+
+    // setup.js does not clean systemConfig; clear any leftover admin password
+    // so authMiddleware runs in open (no-password / desktop) mode for these tests.
+    await prisma.systemConfig.deleteMany();
+
+    await prisma.category.create({ data: { id: 1, nombre: 'Backend', abrev: 'BE' } });
+    await prisma.skill.create({ data: { id: 1, nombre: 'Node.js', categoriaId: 1 } });
+    await prisma.skill.create({ data: { id: 2, nombre: 'SQL', categoriaId: 1 } });
+    // Role profile assigns criticidad 'C' to skill 1 only.
+    await prisma.roleProfile.create({
+      data: { rol: 'Developer', skills: JSON.stringify({ 1: 'C' }) },
+    });
+    collab = await prisma.collaborator.create({
+      data: { nombre: 'Ana', rol: 'Developer', esDemo: false },
+    });
+  });
+
+  describe('PUT /api/collaborators/:id/skills', () => {
+    it('saves a new current assessment and returns success', async () => {
+      const res = await request(app)
+        .put(`/api/collaborators/${collab.id}/skills`)
+        .send({ 1: { nivel: 3, frecuencia: 'D' } });
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+
+      const assessments = await prisma.assessment.findMany({
+        where: { collaboratorId: collab.id, snapshotId: null },
+      });
+      expect(assessments.length).toBe(1);
+      expect(assessments[0].nivel).toBe(3);
+      expect(assessments[0].frecuencia).toBe('D');
+      // criticidad pulled from the role profile
+      expect(assessments[0].criticidad).toBe('C');
+    });
+
+    it("defaults criticidad to 'N' when the skill is not in the role profile", async () => {
+      await request(app)
+        .put(`/api/collaborators/${collab.id}/skills`)
+        .send({ 2: { nivel: 2, frecuencia: 'S' } });
+
+      const a = await prisma.assessment.findFirst({
+        where: { collaboratorId: collab.id, skillId: 2, snapshotId: null },
+      });
+      expect(a.criticidad).toBe('N');
+    });
+
+    it('updates an existing current assessment instead of duplicating', async () => {
+      await request(app)
+        .put(`/api/collaborators/${collab.id}/skills`)
+        .send({ 1: { nivel: 2, frecuencia: 'D' } });
+      await request(app)
+        .put(`/api/collaborators/${collab.id}/skills`)
+        .send({ 1: { nivel: 4, frecuencia: 'S' } });
+
+      const assessments = await prisma.assessment.findMany({
+        where: { collaboratorId: collab.id, skillId: 1, snapshotId: null },
+      });
+      expect(assessments.length).toBe(1);
+      expect(assessments[0].nivel).toBe(4);
+      expect(assessments[0].frecuencia).toBe('S');
+    });
+
+    it('returns 404 for a nonexistent collaborator', async () => {
+      const res = await request(app)
+        .put('/api/collaborators/99999/skills')
+        .send({ 1: { nivel: 3, frecuencia: 'D' } });
+      expect(res.status).toBe(404);
+    });
+
+    it('returns 400 for a level out of the 0-5 range', async () => {
+      const res = await request(app)
+        .put(`/api/collaborators/${collab.id}/skills`)
+        .send({ 1: { nivel: 6, frecuencia: 'D' } });
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 400 for an invalid frequency', async () => {
+      const res = await request(app)
+        .put(`/api/collaborators/${collab.id}/skills`)
+        .send({ 1: { nivel: 3, frecuencia: 'X' } });
+      expect(res.status).toBe(400);
+    });
+
+    it('stamps lastEvaluated on the collaborator', async () => {
+      expect(collab.lastEvaluated).toBeNull();
+      await request(app)
+        .put(`/api/collaborators/${collab.id}/skills`)
+        .send({ 1: { nivel: 3, frecuencia: 'D' } });
+      const after = await prisma.collaborator.findUnique({ where: { id: collab.id } });
+      expect(after.lastEvaluated).not.toBeNull();
+    });
+  });
+
+  describe('POST /api/evaluations', () => {
+    it('creates a session and returns a uuid', async () => {
+      const res = await request(app)
+        .post('/api/evaluations')
+        .send({ collaboratorId: collab.id, skills: { 1: { nivel: 4, frecuencia: 'D' } } });
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(typeof res.body.uuid).toBe('string');
+
+      const session = await prisma.evaluationSession.findUnique({
+        where: { uuid: res.body.uuid },
+        include: { assessments: true },
+      });
+      expect(session).not.toBeNull();
+      // session-linked assessment
+      expect(session.assessments.length).toBe(1);
+      expect(session.assessments[0].nivel).toBe(4);
+      // also mirrors into the current assessment (snapshotId null)
+      const current = await prisma.assessment.findFirst({
+        where: { collaboratorId: collab.id, skillId: 1, snapshotId: null },
+      });
+      expect(current).not.toBeNull();
+      expect(current.nivel).toBe(4);
+    });
+
+    it('returns 400 without a collaboratorId', async () => {
+      const res = await request(app).post('/api/evaluations').send({ skills: {} });
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 404 for a nonexistent collaborator', async () => {
+      const res = await request(app)
+        .post('/api/evaluations')
+        .send({ collaboratorId: 99999, skills: {} });
+      expect(res.status).toBe(404);
+    });
+
+    it('snapshots the collaborator name and role on the session', async () => {
+      const res = await request(app)
+        .post('/api/evaluations')
+        .send({ collaboratorId: collab.id, skills: {} });
+      const session = await prisma.evaluationSession.findUnique({ where: { uuid: res.body.uuid } });
+      expect(session.collaboratorNombre).toBe('Ana');
+      expect(session.collaboratorRol).toBe('Developer');
+    });
+
+    it('silently skips invalid skills but still creates the session', async () => {
+      const res = await request(app)
+        .post('/api/evaluations')
+        .send({
+          collaboratorId: collab.id,
+          skills: {
+            1: { nivel: 9, frecuencia: 'D' }, // invalid level -> skipped
+            2: { nivel: 3, frecuencia: 'S' }, // valid
+          },
+        });
+      const session = await prisma.evaluationSession.findUnique({
+        where: { uuid: res.body.uuid },
+        include: { assessments: true },
+      });
+      expect(session.assessments.length).toBe(1);
+      expect(session.assessments[0].skillId).toBe(2);
+    });
+
+    it('records a role-change note when the role differs from the last session', async () => {
+      // Prior session captured the collaborator as a 'Junior'
+      await prisma.evaluationSession.create({
+        data: { collaboratorId: collab.id, collaboratorNombre: 'Ana', collaboratorRol: 'Junior' },
+      });
+      const res = await request(app)
+        .post('/api/evaluations')
+        .send({ collaboratorId: collab.id, skills: {} });
+      const session = await prisma.evaluationSession.findUnique({ where: { uuid: res.body.uuid } });
+      expect(session.notes).toContain('Role change: Junior → Developer');
+    });
+  });
+
+  describe('GET /api/collaborators/:id/evaluations', () => {
+    it('lists sessions newest-first with assessment counts', async () => {
+      const first = await request(app)
+        .post('/api/evaluations')
+        .send({ collaboratorId: collab.id, skills: { 1: { nivel: 3, frecuencia: 'D' } } });
+      const second = await request(app)
+        .post('/api/evaluations')
+        .send({ collaboratorId: collab.id, skills: {} });
+
+      const res = await request(app).get(`/api/collaborators/${collab.id}/evaluations`);
+      expect(res.status).toBe(200);
+      expect(res.body.length).toBe(2);
+      // newest first
+      expect(res.body[0].uuid).toBe(second.body.uuid);
+      expect(res.body[1].uuid).toBe(first.body.uuid);
+      expect(res.body[1].assessmentCount).toBe(1);
+    });
+  });
+
+  describe('GET /api/evaluations/:uuid', () => {
+    it('returns the session with a skills map', async () => {
+      const created = await request(app)
+        .post('/api/evaluations')
+        .send({ collaboratorId: collab.id, skills: { 1: { nivel: 4, frecuencia: 'D' } } });
+
+      const res = await request(app).get(`/api/evaluations/${created.body.uuid}`);
+      expect(res.status).toBe(200);
+      expect(res.body.uuid).toBe(created.body.uuid);
+      expect(res.body.skills['1'].nivel).toBe(4);
+      expect(res.body.skills['1'].skillName).toBe('Node.js');
+      expect(res.body.skills['1'].categoryName).toBe('Backend');
+    });
+
+    it('returns 404 for an unknown uuid', async () => {
+      const res = await request(app).get('/api/evaluations/does-not-exist');
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe('DELETE /api/evaluations/:uuid', () => {
+    it('deletes the session and its linked assessments', async () => {
+      const created = await request(app)
+        .post('/api/evaluations')
+        .send({ collaboratorId: collab.id, skills: { 1: { nivel: 4, frecuencia: 'D' } } });
+      const uuid = created.body.uuid;
+
+      const res = await request(app).delete(`/api/evaluations/${uuid}`);
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+
+      const session = await prisma.evaluationSession.findUnique({ where: { uuid } });
+      expect(session).toBeNull();
+      const linked = await prisma.assessment.findMany({ where: { evaluationSessionId: { not: null } } });
+      expect(linked.length).toBe(0);
+    });
+
+    it('returns 404 for an unknown uuid', async () => {
+      const res = await request(app).delete('/api/evaluations/does-not-exist');
+      expect(res.status).toBe(404);
+    });
+  });
+});

--- a/server/src/__tests__/evolution.test.js
+++ b/server/src/__tests__/evolution.test.js
@@ -104,6 +104,22 @@ describe('Evolution Routes', () => {
       expect(res.body.insights.topImprover).toBeNull();
       expect(res.body.insights.supportCount).toBe(0);
     });
+
+    it('flags a support case when a critical skill is below the competent threshold', async () => {
+      // Critical skill (C) evaluated below 2.5 -> should surface as a support case.
+      const { collaborator } = await seedEvolutionData({ nivel: 1.0 });
+      await prisma.roleProfile.create({
+        data: { rol: 'Developer', skills: JSON.stringify({ 1: 'C' }) },
+      });
+
+      const res = await request(app).get('/api/skills/evolution');
+
+      expect(res.status).toBe(200);
+      expect(res.body.insights.supportCount).toBeGreaterThanOrEqual(1);
+      const supportCase = res.body.insights.supportCases.find((s) => s.id === collaborator.id);
+      expect(supportCase).toBeDefined();
+      expect(supportCase.criticalGaps).toBeGreaterThanOrEqual(1);
+    });
   });
 
   // ============================================

--- a/server/src/__tests__/export-import.test.js
+++ b/server/src/__tests__/export-import.test.js
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import request from 'supertest';
+import { createApp, prisma } from '../index.js';
+
+// Characterization tests for the data-portability endpoints (GET /api/export,
+// POST /api/import). These guard the serialization/round-trip shape so the
+// Prisma 6->7 migration (createMany, findMany) can't silently break backups.
+
+describe('Data portability endpoints', () => {
+  let app;
+
+  beforeEach(async () => {
+    app = createApp();
+    // Open (no-password) auth mode; setup.js does not clean systemConfig.
+    await prisma.systemConfig.deleteMany();
+
+    await prisma.category.create({ data: { id: 1, nombre: 'Backend', abrev: 'BE' } });
+    await prisma.skill.create({ data: { id: 1, nombre: 'Node.js', categoriaId: 1 } });
+    const collab = await prisma.collaborator.create({
+      data: { id: 1, nombre: 'Ana', rol: 'Developer', esDemo: false },
+    });
+    await prisma.assessment.create({
+      data: { collaboratorId: collab.id, skillId: 1, nivel: 3, criticidad: 'C', frecuencia: 'D' },
+    });
+  });
+
+  describe('GET /api/export', () => {
+    it('returns the canonical envelope with version and data collections', async () => {
+      const res = await request(app).get('/api/export');
+      expect(res.status).toBe(200);
+      expect(res.body.version).toBe('1.0');
+      expect(typeof res.body.exportDate).toBe('string');
+      expect(res.body.data).toHaveProperty('categories');
+      expect(res.body.data).toHaveProperty('skills');
+      expect(res.body.data).toHaveProperty('collaborators');
+      expect(res.body.data).toHaveProperty('assessments');
+      expect(res.body.data).toHaveProperty('snapshots');
+    });
+
+    it('includes the seeded rows in the dump', async () => {
+      const res = await request(app).get('/api/export');
+      expect(res.body.data.categories.length).toBe(1);
+      expect(res.body.data.skills.length).toBe(1);
+      expect(res.body.data.collaborators.length).toBe(1);
+      expect(res.body.data.assessments.length).toBe(1);
+      expect(res.body.data.categories[0].nombre).toBe('Backend');
+    });
+  });
+
+  describe('POST /api/import', () => {
+    it('returns 400 when the data envelope is missing', async () => {
+      const res = await request(app).post('/api/import').send({});
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 400 when skills are missing from the payload', async () => {
+      const res = await request(app).post('/api/import').send({ data: { categories: [] } });
+      expect(res.status).toBe(400);
+    });
+
+    it('wipes existing data and replaces it on import', async () => {
+      const res = await request(app)
+        .post('/api/import')
+        .send({
+          data: {
+            categories: [{ id: 10, nombre: 'Frontend', abrev: 'FE' }],
+            skills: [],
+          },
+        });
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+
+      const categories = await prisma.category.findMany();
+      expect(categories.length).toBe(1);
+      expect(categories[0].nombre).toBe('Frontend');
+      // original Backend category + its skill/collaborator/assessment were wiped
+      expect(await prisma.skill.count()).toBe(0);
+      expect(await prisma.collaborator.count()).toBe(0);
+      expect(await prisma.assessment.count()).toBe(0);
+    });
+
+    it('round-trips a full export back into the database', async () => {
+      const exported = await request(app).get('/api/export');
+
+      const res = await request(app).post('/api/import').send({ data: exported.body.data });
+      expect(res.status).toBe(200);
+
+      expect(await prisma.category.count()).toBe(1);
+      expect(await prisma.skill.count()).toBe(1);
+      expect(await prisma.collaborator.count()).toBe(1);
+      expect(await prisma.assessment.count()).toBe(1);
+      const a = await prisma.assessment.findFirst();
+      expect(a.nivel).toBe(3);
+      expect(a.criticidad).toBe('C');
+    });
+  });
+});

--- a/server/src/__tests__/security.test.js
+++ b/server/src/__tests__/security.test.js
@@ -101,6 +101,13 @@ describe('Demo Mode — Completeness Check', () => {
     ['PUT', '/api/development-goals/1'],
     ['POST', '/api/development-goals/1/actions'],
     ['PUT', '/api/development-actions/1'],
+    // Previously-unprotected mutators — the allowlist model now blocks them:
+    ['POST', '/api/collaborators'],
+    ['PUT', '/api/collaborators/1'],
+    ['PUT', '/api/collaborators/1/skills'],
+    ['POST', '/api/evaluations'],
+    ['PUT', '/api/role-profiles/TestRole'],
+    ['PUT', '/api/categories/reorder'],
   ];
 
   destructiveEndpoints.forEach(([method, path]) => {

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -18,6 +18,15 @@ export { prisma };
 export function createApp() {
   const app = express();
 
+  // Behind a reverse proxy (Cloudflare/Nginx in the hosted demo), trust the
+  // first hop so req.ip is the real client and the login rate limiter buckets
+  // correctly. Off by default so a directly-exposed instance can't spoof its
+  // IP via X-Forwarded-For. Set TRUST_PROXY=1 (or a hop count) in the deploy.
+  if (process.env.TRUST_PROXY) {
+    const hops = Number(process.env.TRUST_PROXY);
+    app.set('trust proxy', Number.isNaN(hops) ? process.env.TRUST_PROXY : hops);
+  }
+
   // Security headers
   app.disable('x-powered-by');
   app.use((req, res, next) => {
@@ -28,7 +37,27 @@ export function createApp() {
     next();
   });
 
-  app.use(cors());
+  // CORS: permissive by default (the desktop Tauri webview and local dev call
+  // the API cross-origin and rely on this). Hosted deployments lock it down by
+  // setting ALLOWED_ORIGINS to a comma-separated origin list; a non-allowlisted
+  // browser origin then receives no CORS header and is blocked by the browser.
+  const allowedOrigins = process.env.ALLOWED_ORIGINS
+    ? process.env.ALLOWED_ORIGINS.split(',').map((o) => o.trim()).filter(Boolean)
+    : null;
+  app.use(
+    cors(
+      allowedOrigins
+        ? {
+            origin(origin, cb) {
+              // No Origin header = same-origin or non-browser client (curl,
+              // server-to-server) — always allowed.
+              if (!origin || allowedOrigins.includes(origin)) return cb(null, true);
+              return cb(null, false);
+            },
+          }
+        : undefined
+    )
+  );
   app.use(express.json({ limit: '1mb' }));
   app.use(cookieParser());
 

--- a/server/src/middleware/demo.js
+++ b/server/src/middleware/demo.js
@@ -1,38 +1,33 @@
-const DEMO_BLOCKED = [
-  ['POST',   /^\/api\/reset-database$/],
-  ['POST',   /^\/api\/setup$/],
-  ['POST',   /^\/api\/reset-demo$/],
-  ['POST',   /^\/api\/import$/],
-  ['PUT',    /^\/api\/config$/],
-  ['DELETE', /^\/api\/categories\/\d+$/],
-  ['DELETE', /^\/api\/collaborators\/\d+$/],
-  ['DELETE', /^\/api\/skills\/\d+$/],
-  ['DELETE', /^\/api\/role-profiles\/[^/]+$/],
-  ['DELETE', /^\/api\/evaluations\/[^/]+$/],
-  ['DELETE', /^\/api\/development-plans\/\d+$/],
-  ['DELETE', /^\/api\/development-goals\/\d+$/],
-  ['DELETE', /^\/api\/development-actions\/\d+$/],
-  ['POST',   /^\/api\/development-plans$/],
-  ['PUT',    /^\/api\/development-plans\/\d+$/],
-  ['POST',   /^\/api\/development-plans\/\d+\/goals$/],
-  ['PUT',    /^\/api\/development-goals\/\d+$/],
-  ['POST',   /^\/api\/development-goals\/\d+\/actions$/],
-  ['PUT',    /^\/api\/development-actions\/\d+$/],
+// Demo-mode guard for the public online demo (skima.henfrydls.com).
+//
+// Allowlist model: when DEMO_MODE=true the shared demo must stay read-only.
+// All safe reads (GET/HEAD/OPTIONS) pass through, plus an explicit allowlist of
+// safe write operations (auth + demo seeding). EVERY other mutation is blocked
+// by default — so a newly-added write endpoint is protected automatically
+// instead of leaking until someone remembers to deny-list it.
+
+const SAFE_METHODS = new Set(['GET', 'HEAD', 'OPTIONS']);
+
+const DEMO_ALLOWED_MUTATIONS = [
+  ['POST', /^\/api\/auth\/login$/],
+  ['POST', /^\/api\/config\/verify$/],
+  ['POST', /^\/api\/seed-demo$/],
 ];
 
 export function demoModeMiddleware(req, res, next) {
   if (process.env.DEMO_MODE !== 'true') return next();
 
-  const blocked = DEMO_BLOCKED.some(
+  // Reads are always safe.
+  if (SAFE_METHODS.has(req.method)) return next();
+
+  // Mutations are denied unless explicitly allowlisted.
+  const allowed = DEMO_ALLOWED_MUTATIONS.some(
     ([method, pattern]) => req.method === method && pattern.test(req.path)
   );
+  if (allowed) return next();
 
-  if (blocked) {
-    return res.status(403).json({
-      error: 'DEMO_MODE',
-      message: 'This action is not available in demo mode.',
-    });
-  }
-
-  next();
+  return res.status(403).json({
+    error: 'DEMO_MODE',
+    message: 'This action is not available in demo mode.',
+  });
 }

--- a/server/src/routes/demo.js
+++ b/server/src/routes/demo.js
@@ -11,11 +11,47 @@ import {
 
 const router = Router();
 
+// Per-IP rate limit for demo reseeds. seed-demo wipes + reseeds every table in
+// a ~30s transaction; on the public demo it is unauthenticated and allowlisted,
+// so without a limit anyone could hammer it as a DoS lever. Only enforced when
+// DEMO_MODE=true — the desktop app (and tests not in demo mode) are unaffected.
+// req.ip is reliable behind the proxy thanks to the TRUST_PROXY setting.
+const seedAttempts = new Map();
+const SEED_MAX = 3;
+const SEED_WINDOW_MS = 5 * 60 * 1000; // 5 minutes
+
+function checkSeedRateLimit(ip) {
+  const now = Date.now();
+  const record = seedAttempts.get(ip);
+  if (!record || now - record.firstAttempt > SEED_WINDOW_MS) {
+    seedAttempts.set(ip, { count: 1, firstAttempt: now });
+    return true;
+  }
+  if (record.count >= SEED_MAX) return false;
+  record.count++;
+  return true;
+}
+
+// Allow tests to reset rate limiter state between cases.
+export function resetSeedRateLimiter() {
+  seedAttempts.clear();
+}
+
 // ============================================================
 // POST /api/seed-demo - Seed rich demo data for first-time experience
 // Uses the same chaos testing dataset as prisma/seed.js
 // ============================================================
 router.post('/', async (req, res) => {
+  // Throttle reseeds on the public demo only.
+  if (process.env.DEMO_MODE === 'true') {
+    const ip = req.ip || req.socket?.remoteAddress || 'unknown';
+    if (!checkSeedRateLimit(ip)) {
+      return res.status(429).json({
+        error: 'RATE_LIMITED',
+        message: 'Too many demo resets. Please wait a few minutes and try again.',
+      });
+    }
+  }
   try {
     // Wrap entire seed operation in transaction for atomicity
     const snapshotCount = await prisma.$transaction(async (tx) => {

--- a/server/src/routes/development.js
+++ b/server/src/routes/development.js
@@ -35,7 +35,7 @@ router.get('/development-plans', async (req, res) => {
       include: {
         collaborator: true,
         goals: {
-          include: { actions: true },
+          include: { actions: true, skill: { select: { id: true, nombre: true } } },
           orderBy: { sortOrder: 'asc' }
         }
       },
@@ -60,7 +60,7 @@ router.get('/development-plans/:id', async (req, res) => {
       include: {
         collaborator: true,
         goals: {
-          include: { actions: true },
+          include: { actions: true, skill: { select: { id: true, nombre: true } } },
           orderBy: { sortOrder: 'asc' }
         }
       }

--- a/server/src/routes/evolution.js
+++ b/server/src/routes/evolution.js
@@ -438,7 +438,8 @@ router.get('/', async (req, res) => {
     
   } catch (error) {
     console.error('[API] GET /api/skills/evolution failed:', error);
-    res.status(500).json({ message: 'Error fetching evolution data', error: error.message });
+    // Don't leak internal error details to the client.
+    res.status(500).json({ message: 'Error fetching evolution data' });
   }
 });
 

--- a/server/src/routes/evolution.js
+++ b/server/src/routes/evolution.js
@@ -360,21 +360,32 @@ router.get('/', async (req, res) => {
     
     // For each employee, check their latest assessments against role profile
     const supportCases = [];
-    
+
+    // Pre-fetch the latest in-range session per employee in ONE query, instead
+    // of a findFirst per employee (N+1). The query is globally ordered by
+    // evaluatedAt desc, so the first row seen for a collaborator is their latest.
+    const inRangeSessions = await prisma.evaluationSession.findMany({
+      where: {
+        collaboratorId: { in: employees.map((e) => e.id) },
+        evaluatedAt: { gte: startDate, lte: endDate }
+      },
+      orderBy: { evaluatedAt: 'desc' },
+      include: { assessments: true }
+    });
+    const latestSessionByCollaborator = new Map();
+    for (const s of inRangeSessions) {
+      if (!latestSessionByCollaborator.has(s.collaboratorId)) {
+        latestSessionByCollaborator.set(s.collaboratorId, s);
+      }
+    }
+
     for (const emp of employees) {
       const roleSkills = profileMap.get(emp.role);
       if (!roleSkills) continue; // No profile = no gaps to calculate
-      
-      // Get latest session for this employee
-      const latestSession = await prisma.evaluationSession.findFirst({
-        where: { 
-          collaboratorId: emp.id,
-          evaluatedAt: { gte: startDate, lte: endDate }
-        },
-        orderBy: { evaluatedAt: 'desc' },
-        include: { assessments: true }
-      });
-      
+
+      // Latest in-range session for this employee (from the pre-fetched map)
+      const latestSession = latestSessionByCollaborator.get(emp.id);
+
       if (!latestSession) continue;
       
       // Create skill level map from assessments


### PR DESCRIPTION
Hardening + polish release ahead of the public launch. No new user features — the goal is a demo that's safe to expose and the Development Plans feature completed.

Closes #36, #37, #38, #52.

## Security (launch blocker)
- **Demo mode → allowlist.** The demo guard used a deny-list, so any unlisted mutation leaked through — a public visitor on skima.henfrydls.com could create/edit collaborators, evaluations and role profiles. Now reads pass; only auth + seed-demo writes are permitted; every other mutation returns 403. New write endpoints are protected by default.
- **CORS allowlist + trust proxy**, both env-driven (`ALLOWED_ORIGINS`, `TRUST_PROXY`). Permissive by default so the desktop Tauri webview and local dev keep working; hosted deployments lock down. Trust proxy lets the login rate limiter bucket by real client IP behind Cloudflare/Nginx.
- Stop leaking internal `error.message` from the evolution endpoint.

## Development Plans (#36/#37/#38)
The feature shipped half-baked: the goal form saved `priority` (1/2/3) and `targetLevel`, but the UI never showed them — priority was keyed by string against an integer, so every goal rendered as medium. Adds a shared `getPriorityMeta()` helper (normalizes int + legacy string), a target-level badge, and a descriptive tooltip on the linked-skill badge — in both GoalAccordion and DevelopmentTab.

## Updater (#52)
- "Preparing…" state during the ~1.5s sidecar shutdown window, instead of a frozen "Downloading 0%" bar.
- Auto-check is skipped in `tauri:dev` (gated on `import.meta.env.MODE`) so the modal no longer pops over a dev session; manual check still works.

## Tests / perf
- Characterization tests for the highest-risk Prisma write paths (evaluations CRUD, export/import) as a regression net for the upcoming v1.5.0 migration.
- Fixed an N+1 in the evolution support-cases loop (one findFirst per employee → single batched query).

## Validation
- Server 210/210, client 914/914 (1124 total). Lint clean. `npm run build` clean.

## Deferred to v1.5.0 (with rationale)
- **#67 (hdiutil CI flake):** the race is inside `tauri-action` (a `uses:` step) which Actions can't natively retry; a real fix is an unvalidatable pipeline restructuring better done alongside the Bun CI rework.
- **Legacy plaintext-password removal:** the auth suite depends on the auto-upgrade path and removal would lock out legacy plaintext installs; proper fix is a re-hash-at-boot migration.