### PR TITLE
release: v1.4.2

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "skima",
   "private": true,
-  "version": "1.4.1",
+  "version": "1.4.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skima",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "private": true,
   "description": "Skima - People Development Platform",
   "scripts": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skima-server",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "private": true,
   "type": "module",
   "bin": "src/index.js",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3205,7 +3205,7 @@ checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "skima"
-version = "1.4.0"
+version = "1.4.2"
 dependencies = [
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skima"
-version = "1.4.1"
+version = "1.4.2"
 description = "Skima - People Development Platform"
 authors = ["DLSLabs"]
 edition = "2024"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Skima",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "identifier": "com.dlslabs.skima",
   "build": {
     "beforeDevCommand": "npm run dev:client",


### PR DESCRIPTION
Version bump 1.4.1 → 1.4.2 for the release of the launch-hardening work merged in #68.

Bumps: root/client/server package.json, tauri.conf.json, Cargo.toml, Cargo.lock (skima 1.4.0 → 1.4.2 — the lock had drifted).

After this merges, tag `v1.4.2` on main to trigger the release CI (build matrix + signed bundles + latest.json + GitHub release).

Release contents (from #68):
- Demo mode → allowlist (closes public-write holes) + per-IP seed-demo rate limit
- Env-driven CORS allowlist + trust proxy
- Development Plans: priority/target level visible + skill tooltip (closes #36, #37, #38)
- Updater: "Preparing" state + dev auto-check gate (closes #52)
- Evolution N+1 fix, error-leak fix, regression test coverage