### PR TITLE
ci(docker): disable provenance attestation to fix GHCR push failures

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -35,6 +35,10 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest,enable={{is_default_branch}}
+            # Lets a manual workflow_dispatch on a feature branch produce a
+            # throwaway tag (= branch name) so the image build/push path can be
+            # exercised without cutting a release tag.
+            type=ref,event=branch
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
@@ -43,3 +47,9 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          # GHCR rejects the SLSA provenance attestation manifest that buildx
+          # attaches by default ("ERROR: unknown blob" on push), especially
+          # after a package version has been deleted and its blobs are pending
+          # garbage collection. We don't consume the attestation anywhere, so
+          # disable it to keep pushes deterministic.
+          provenance: false


### PR DESCRIPTION
## Problema

El workflow `Docker / build-and-push` falla en el push a GHCR con `ERROR: unknown blob`. Ocurre de forma reproducible cuando una versión del package fue **borrada** previamente y sus blobs siguen en garbage-collection pendiente: buildx adjunta por defecto un manifest de attestation SLSA (provenance), y GHCR lo rechaza al pushear.

Visto en los re-runs del release v1.4.2 (run `27082660059`): los layers suben correctamente y luego falla con `unknown blob` al pushear el manifest.

## Causa raíz

`docker/build-push-action@v6` agrega un attestation de provenance por defecto. Ese manifest extra dispara el `unknown blob` en GHCR. No consumimos la attestation en ningún lado.

## Fix

- `provenance: false` en el step de build-push → push determinista, sin el manifest de attestation.
- `type=ref,event=branch` en los tags de metadata → permite verificar el path de build/push con un `workflow_dispatch` sobre una rama (produce un tag throwaway = nombre de rama) sin tener que cortar un tag de release.

## Verificación

- El package v1.4.2 ya fue republicado a mano (`docker buildx --provenance=false --platform linux/amd64`) — `1.4.2`, `1.4`, `latest` presentes en GHCR con el mismo digest.
- Este PR exercita el mismo `provenance: false` vía CI disparando el workflow sobre la rama.

## Nota

La X en el commit `e4638b1` (merge de #69) queda histórica: ese commit no tiene el fix y re-correr su workflow vuelve a fallar. Este PR asegura que los **próximos** releases pasen verdes.