### PR TITLE
fix(dev-plans): editable / backdatable action completion date

### DIFF
--- a/client/src/components/settings/DevelopmentActionFormModal.jsx
+++ b/client/src/components/settings/DevelopmentActionFormModal.jsx
@@ -23,6 +23,7 @@ export default function ActionFormModal({ action = null, onClose, onSubmit }) {
     actionType: action?.actionType || 'experience',
     description: action?.description || '',
     dueDate: action?.dueDate?.slice(0, 10) || '',
+    completedAt: action?.completedAt?.slice(0, 10) || '',
   });
 
   const handleChange = (e) => {
@@ -34,15 +35,26 @@ export default function ActionFormModal({ action = null, onClose, onSubmit }) {
     e.preventDefault();
     if (!form.title.trim()) return;
     setSaving(true);
+    const { completedAt, ...rest } = form;
+    const originalCompletedAt = action?.completedAt?.slice(0, 10) || '';
     const payload = {
-      ...form,
+      ...rest,
       dueDate: form.dueDate || null,
+      // Only send completedAt if the user actually changed it. Re-sending the
+      // date-only value on an unrelated edit (e.g. just the title) would truncate
+      // the stored time-of-day and can shift the displayed date across a timezone
+      // boundary.
+      ...(action?.status === 'completed' && completedAt !== originalCompletedAt
+        ? { completedAt: completedAt || null }
+        : {}),
     };
     await onSubmit(payload);
     setSaving(false);
   };
 
   useFocusTrap();
+
+  const today = new Date().toISOString().slice(0, 10);
 
   const inputClass = 'w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary transition-colors';
   const labelClass = 'block text-xs text-gray-400 uppercase tracking-wide mb-1';
@@ -117,6 +129,22 @@ export default function ActionFormModal({ action = null, onClose, onSubmit }) {
             <label className={labelClass}>Due Date</label>
             <input type="date" name="dueDate" value={form.dueDate} onChange={handleChange} className={inputClass} />
           </div>
+
+          {/* Completed date — editable only for an already-completed action (allows backdating) */}
+          {action?.status === 'completed' && (
+            <div>
+              <label className={labelClass}>Completed Date</label>
+              <input
+                type="date"
+                name="completedAt"
+                value={form.completedAt}
+                onChange={handleChange}
+                max={today}
+                className={inputClass}
+              />
+              <p className="text-xs text-gray-400 mt-1">Can&apos;t be later than today.</p>
+            </div>
+          )}
 
           <div className="flex justify-end gap-3 pt-2">
             <Button variant="secondary" type="button" onClick={onClose}>Cancel</Button>

--- a/client/src/components/settings/__tests__/DevelopmentActionFormModal.test.jsx
+++ b/client/src/components/settings/__tests__/DevelopmentActionFormModal.test.jsx
@@ -83,6 +83,61 @@ describe('DevelopmentActionFormModal', () => {
     expect(formalTile.className).toMatch(/border/);
   });
 
+  it('shows an editable Completed Date for a completed action and submits the backdated value', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    const existing = {
+      id: 9, title: 'Done action', actionType: 'formal', description: '',
+      dueDate: null, status: 'completed', completedAt: '2026-06-10T00:00:00.000Z',
+    };
+    renderModal({ action: existing, onSubmit });
+
+    expect(screen.getByText(/Completed Date/i)).toBeInTheDocument();
+    const dateInput = document.querySelector('input[name="completedAt"]');
+    expect(dateInput).not.toBeNull();
+    expect(dateInput.value).toBe('2026-06-10');
+
+    // Backdate it
+    fireEvent.change(dateInput, { target: { value: '2020-01-15' } });
+    fireEvent.click(screen.getByRole('button', { name: /Save Changes/i }));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    expect(onSubmit.mock.calls[0][0].completedAt).toBe('2020-01-15');
+  });
+
+  it('does not resend completedAt when editing a completed action without touching the date', async () => {
+    // Regression: re-sending the date-only value on an unrelated edit truncated the
+    // stored time-of-day and could shift the displayed date across a timezone boundary.
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    const existing = {
+      id: 11, title: 'Done', actionType: 'formal', description: '',
+      dueDate: null, status: 'completed', completedAt: '2026-06-10T14:30:00.000Z',
+    };
+    renderModal({ action: existing, onSubmit });
+
+    // Edit only the title — leave the completion date untouched
+    fireEvent.change(screen.getByDisplayValue('Done'), { target: { value: 'Done (edited)' } });
+    fireEvent.click(screen.getByRole('button', { name: /Save Changes/i }));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    expect(onSubmit.mock.calls[0][0]).not.toHaveProperty('completedAt');
+    expect(onSubmit.mock.calls[0][0].title).toBe('Done (edited)');
+  });
+
+  it('hides Completed Date and omits it from the payload for a non-completed action', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    const existing = {
+      id: 10, title: 'In progress', actionType: 'experience', description: '',
+      dueDate: null, status: 'in_progress',
+    };
+    renderModal({ action: existing, onSubmit });
+
+    expect(document.querySelector('input[name="completedAt"]')).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: /Save Changes/i }));
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    expect(onSubmit.mock.calls[0][0]).not.toHaveProperty('completedAt');
+  });
+
   it('persists changed actionType when editing', async () => {
     const onSubmit = vi.fn().mockResolvedValue(undefined);
     const existing = {

--- a/server/src/__tests__/development.test.js
+++ b/server/src/__tests__/development.test.js
@@ -425,6 +425,45 @@ describe('Development Plans API', () => {
       expect(res.body.completedAt).not.toBeNull();
     });
 
+    it('PUT /api/development-actions/:id — accepts an explicit (backdated) completedAt when completing', async () => {
+      const action = await prisma.developmentAction.create({
+        data: { goalId: goal.id, title: 'Action' }
+      });
+
+      const res = await request(app)
+        .put(`/api/development-actions/${action.id}`)
+        .send({ status: 'completed', completedAt: '2020-01-15' });
+
+      expect(res.status).toBe(200);
+      expect(new Date(res.body.completedAt).toISOString().slice(0, 10)).toBe('2020-01-15');
+    });
+
+    it('PUT /api/development-actions/:id — edits completedAt on a completed action without changing status', async () => {
+      const action = await prisma.developmentAction.create({
+        data: { goalId: goal.id, title: 'Action', status: 'completed', completedAt: new Date() }
+      });
+
+      const res = await request(app)
+        .put(`/api/development-actions/${action.id}`)
+        .send({ completedAt: '2020-02-01' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.status).toBe('completed');
+      expect(new Date(res.body.completedAt).toISOString().slice(0, 10)).toBe('2020-02-01');
+    });
+
+    it('PUT /api/development-actions/:id — rejects a future completedAt', async () => {
+      const action = await prisma.developmentAction.create({
+        data: { goalId: goal.id, title: 'Action' }
+      });
+
+      const res = await request(app)
+        .put(`/api/development-actions/${action.id}`)
+        .send({ status: 'completed', completedAt: '2099-12-31' });
+
+      expect(res.status).toBe(400);
+    });
+
     it('PUT /api/development-actions/:id — clears completedAt when status changes away from completed', async () => {
       const action = await prisma.developmentAction.create({
         data: { goalId: goal.id, title: 'Action', status: 'completed', completedAt: new Date() }

--- a/server/src/routes/development.js
+++ b/server/src/routes/development.js
@@ -362,7 +362,7 @@ router.put('/development-actions/:id', authMiddleware, async (req, res) => {
   try {
     const id = parseInt(req.params.id, 10);
     if (isNaN(id)) return res.status(400).json({ message: 'Invalid ID' });
-    const { title, description, actionType, status, dueDate, evidence, sortOrder } = req.body;
+    const { title, description, actionType, status, dueDate, completedAt, evidence, sortOrder } = req.body;
 
     const VALID_ACTION_STATUSES = ['not_started', 'in_progress', 'completed', 'skipped'];
     if (status && !VALID_ACTION_STATUSES.includes(status)) {
@@ -370,6 +370,25 @@ router.put('/development-actions/:id', authMiddleware, async (req, res) => {
     }
     if (evidence && evidence.length > 2000) {
       return res.status(400).json({ message: 'Evidence must be under 2000 characters' });
+    }
+
+    // Validate an explicit completion date if provided. Allows backdating (a user
+    // finished the action in the past), but rejects invalid dates and future dates
+    // — you can't complete something later than now. 24h tolerance so a date-only
+    // "today" from any timezone is never wrongly rejected.
+    let parsedCompletedAt;
+    const hasCompletedAt = completedAt !== undefined && completedAt !== null && completedAt !== '';
+    if (hasCompletedAt) {
+      if (typeof completedAt !== 'string') {
+        return res.status(400).json({ message: 'Invalid completion date' });
+      }
+      parsedCompletedAt = new Date(completedAt);
+      if (isNaN(parsedCompletedAt.getTime())) {
+        return res.status(400).json({ message: 'Invalid completion date' });
+      }
+      if (parsedCompletedAt.getTime() > Date.now() + 24 * 60 * 60 * 1000) {
+        return res.status(400).json({ message: 'Completion date cannot be in the future' });
+      }
     }
 
     const data = {};
@@ -383,10 +402,15 @@ router.put('/development-actions/:id', authMiddleware, async (req, res) => {
     if (status !== undefined) {
       data.status = status;
       if (status === 'completed') {
-        data.completedAt = new Date();
+        // Use the explicit (possibly backdated) date if given, else stamp now.
+        data.completedAt = parsedCompletedAt || new Date();
       } else {
         data.completedAt = null;
       }
+    } else if (completedAt !== undefined) {
+      // Editing the completion date without changing status (e.g. backdating an
+      // already-completed action). Empty/null clears it.
+      data.completedAt = hasCompletedAt ? parsedCompletedAt : null;
     }
 
     const action = await prisma.developmentAction.update({


### PR DESCRIPTION
Completing a development action hardcoded `completedAt = now` and offered no way to change it, so a task actually finished in the past could only be recorded as done today.

## Changes
- **Backend** (`PUT /api/development-actions/:id`): accepts an optional `completedAt` — used when completing (else stamps now), and editable on an already-completed action without changing status. Rejects invalid and future dates (24h tolerance for date-only timezone drift), and guards non-string input.
- **Frontend** (`DevelopmentActionFormModal`): adds a "Completed Date" field shown only when the action is completed (`max=today`, hint "Can't be later than today."). Sent only when the user actually changed it — re-sending the date-only value on an unrelated edit would truncate the stored time-of-day and could shift the displayed date across a timezone boundary (regression caught in review).

## Validation
- Server 214→217 tests, action modal 5→8 tests (incl. backdate, edit-without-status-change, future-reject, and the no-resend regression test). Lint clean.
- Reviewed by UX, code-review, and QA passes.

Scope note: sibling goal/plan completion endpoints have the same pre-existing auto-stamp limitation — intentionally left out of scope.