### PR TITLE
feat: complete backup & restore (#71)

### DIFF
--- a/client/src/components/settings/BackupTab.jsx
+++ b/client/src/components/settings/BackupTab.jsx
@@ -1,0 +1,217 @@
+import { useState, useRef } from 'react';
+import { Download, Upload, AlertTriangle } from 'lucide-react';
+import toast from 'react-hot-toast';
+import Button from '../common/Button';
+import ConfirmModal from '../common/ConfirmModal';
+import { useAuth } from '../../contexts/AuthContext';
+import { useConfig } from '../../contexts/ConfigContext';
+import { API_BASE } from '../../lib/apiBase';
+
+// Collections surfaced in the file summary (friendly order + labels).
+const SUMMARY_KEYS = [
+  ['collaborators', 'collaborators'],
+  ['skills', 'skills'],
+  ['categories', 'categories'],
+  ['roleProfiles', 'role profiles'],
+  ['assessments', 'assessments'],
+  ['evaluationSessions', 'evaluation sessions'],
+  ['developmentPlans', 'development plans'],
+  ['objectives', 'objectives'],
+  ['reviews', 'reviews'],
+  ['kpis', 'KPIs'],
+];
+
+/**
+ * BackupTab — export a full JSON snapshot and restore from one.
+ * Restore is destructive (replaces ALL data) and disabled in the online demo.
+ */
+export default function BackupTab() {
+  const { authFetch } = useAuth();
+  const { isDemo } = useConfig();
+  const fileInputRef = useRef(null);
+
+  const [exporting, setExporting] = useState(false);
+  const [parsing, setParsing] = useState(false);
+  const [parsed, setParsed] = useState(null); // { fileName, exportDate, version, data, counts }
+  const [parseError, setParseError] = useState(null);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [restoring, setRestoring] = useState(false);
+  const [restored, setRestored] = useState(false);
+
+  const card = 'bg-white rounded-lg border border-gray-200 p-6 space-y-4';
+  const heading = 'text-sm font-semibold text-gray-900 uppercase tracking-wide';
+
+  const handleExport = async () => {
+    setExporting(true);
+    try {
+      const res = await authFetch(`${API_BASE}/api/export`);
+      if (!res.ok) throw new Error('Export failed');
+      const json = await res.json();
+      const date = (json.exportDate || new Date().toISOString()).slice(0, 10);
+      const blob = new Blob([JSON.stringify(json, null, 2)], { type: 'application/json' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `skima-backup-${date}.json`;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+      toast.success('Backup downloaded');
+    } catch (err) {
+      if (err.message !== 'SESSION_EXPIRED') toast.error('Error exporting data');
+    } finally {
+      setExporting(false);
+    }
+  };
+
+  const handleFile = async (e) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setParsed(null);
+    setParseError(null);
+    setParsing(true);
+    try {
+      const text = await new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () => resolve(reader.result);
+        reader.onerror = () => reject(reader.error || new Error('Could not read file'));
+        reader.readAsText(file);
+      });
+      let obj;
+      try {
+        obj = JSON.parse(text);
+      } catch {
+        setParseError("This file isn't valid JSON. Choose a Skima backup file (.json).");
+        return;
+      }
+      if (!obj?.data || !Array.isArray(obj.data.categories) || !Array.isArray(obj.data.skills)) {
+        setParseError("This doesn't look like a Skima backup file (missing expected data).");
+        return;
+      }
+      const counts = SUMMARY_KEYS
+        .map(([key, label]) => [Array.isArray(obj.data[key]) ? obj.data[key].length : 0, label])
+        .filter(([n]) => n > 0)
+        .map(([n, label]) => `${n} ${label}`);
+      setParsed({ fileName: file.name, exportDate: obj.exportDate, version: obj.version, data: obj.data, counts });
+    } finally {
+      setParsing(false);
+      if (fileInputRef.current) fileInputRef.current.value = ''; // allow re-selecting same file
+    }
+  };
+
+  const handleRestore = async () => {
+    setRestoring(true);
+    try {
+      const res = await authFetch(`${API_BASE}/api/import`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ data: parsed.data }),
+      });
+      if (res.status === 403) {
+        toast.error('Restoring is not available in demo mode');
+        setConfirmOpen(false);
+        setRestoring(false);
+        return;
+      }
+      if (!res.ok) throw new Error('Import failed');
+      setRestored(true);
+      setTimeout(() => window.location.reload(), 1200);
+    } catch (err) {
+      if (err.message !== 'SESSION_EXPIRED') toast.error('Error importing data');
+      setRestoring(false); // keep modal open to retry
+    }
+  };
+
+  return (
+    <div className="space-y-6 max-w-2xl">
+      {/* Export */}
+      <div className={card}>
+        <div>
+          <h3 className={heading}>Export Data</h3>
+          <p className="text-xs text-gray-500 mt-0.5">
+            Download a complete snapshot of your Skima data — collaborators, skills, evaluations, IDPs, OKRs, and reviews.
+          </p>
+        </div>
+        <Button variant="primary" size="sm" onClick={handleExport} isLoading={exporting} disabled={exporting}>
+          <Download size={14} className="mr-1.5" />
+          Download Backup
+        </Button>
+      </div>
+
+      {/* Restore */}
+      <div className={card}>
+        <h3 className={heading}>Restore from Backup</h3>
+
+        <div className="bg-warning/10 border border-warning/20 rounded-lg p-3 text-xs text-warning flex items-start gap-2">
+          <AlertTriangle size={14} className="flex-shrink-0 mt-0.5" />
+          <span>Restoring replaces ALL current data. This cannot be undone.</span>
+        </div>
+
+        {isDemo ? (
+          <p className="text-sm text-gray-500 italic">Restoring is not available in the online demo.</p>
+        ) : (
+          <>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept=".json,application/json"
+              onChange={handleFile}
+              className="hidden"
+              data-testid="backup-file-input"
+            />
+            <div className="flex items-center gap-3">
+              <Button variant="secondary" size="sm" onClick={() => fileInputRef.current?.click()} disabled={parsing}>
+                <Upload size={14} className="mr-1.5" />
+                Choose File
+              </Button>
+              {parsing && <span className="text-xs text-gray-400">Parsing…</span>}
+              {parsed && <span className="text-xs text-gray-500 truncate max-w-[16rem]">{parsed.fileName}</span>}
+            </div>
+
+            {parseError && (
+              <div className="border border-critical bg-critical/5 text-critical text-sm rounded-lg p-3">
+                {parseError}
+              </div>
+            )}
+
+            {parsed && (
+              <div className="bg-gray-50 border border-gray-200 rounded-lg p-4 text-sm space-y-1">
+                <div className="text-gray-700">
+                  {parsed.counts.length ? parsed.counts.join(' · ') : 'No records in this backup.'}
+                </div>
+                <div className="text-xs text-gray-400">
+                  {parsed.exportDate ? `Exported ${parsed.exportDate.slice(0, 10)}` : 'Unknown date'} · format v{parsed.version || '?'}
+                </div>
+                {parsed.version === '1.0' && (
+                  <div className="text-xs text-gray-500">
+                    Legacy format (v1.0) — newer collections (IDPs, OKRs, reviews) will be skipped.
+                  </div>
+                )}
+              </div>
+            )}
+
+            <Button variant="danger" size="sm" onClick={() => setConfirmOpen(true)} disabled={!parsed || restoring}>
+              Restore from Backup
+            </Button>
+          </>
+        )}
+      </div>
+
+      <ConfirmModal
+        isOpen={confirmOpen}
+        onClose={() => { if (!restoring) setConfirmOpen(false); }}
+        onConfirm={handleRestore}
+        variant="danger"
+        title={restored ? 'Restore complete' : 'Replace All Data?'}
+        message={
+          restored
+            ? 'Reloading…'
+            : `This will permanently delete everything currently in Skima and replace it with the contents of ${parsed?.fileName || 'the backup'}${parsed?.counts?.length ? ` (${parsed.counts.join(', ')})` : ''}. This cannot be undone.`
+        }
+        confirmText="Wipe & Restore"
+        isLoading={restoring}
+      />
+    </div>
+  );
+}

--- a/client/src/components/settings/BackupTab.jsx
+++ b/client/src/components/settings/BackupTab.jsx
@@ -7,18 +7,29 @@ import { useAuth } from '../../contexts/AuthContext';
 import { useConfig } from '../../contexts/ConfigContext';
 import { API_BASE } from '../../lib/apiBase';
 
-// Collections surfaced in the file summary (friendly order + labels).
+// Every backup-able collection, with friendly labels. All 20 are covered so the
+// summary never says "No records" when a backup only holds less-common data.
 const SUMMARY_KEYS = [
   ['collaborators', 'collaborators'],
   ['skills', 'skills'],
   ['categories', 'categories'],
   ['roleProfiles', 'role profiles'],
   ['assessments', 'assessments'],
+  ['snapshots', 'snapshots'],
   ['evaluationSessions', 'evaluation sessions'],
   ['developmentPlans', 'development plans'],
+  ['developmentGoals', 'goals'],
+  ['developmentActions', 'actions'],
+  ['timePeriods', 'time periods'],
   ['objectives', 'objectives'],
+  ['keyResults', 'key results'],
+  ['checkIns', 'check-ins'],
+  ['reviewCycles', 'review cycles'],
   ['reviews', 'reviews'],
+  ['reviewSkillRatings', 'skill ratings'],
   ['kpis', 'KPIs'],
+  ['kpiEntries', 'KPI entries'],
+  ['checkInNotes', 'check-in notes'],
 ];
 
 /**
@@ -110,6 +121,12 @@ export default function BackupTab() {
       });
       if (res.status === 403) {
         toast.error('Restoring is not available in demo mode');
+        setConfirmOpen(false);
+        setRestoring(false);
+        return;
+      }
+      if (res.status === 413) {
+        toast.error('This backup is too large to restore.');
         setConfirmOpen(false);
         setRestoring(false);
         return;

--- a/client/src/components/settings/__tests__/BackupTab.test.jsx
+++ b/client/src/components/settings/__tests__/BackupTab.test.jsx
@@ -60,6 +60,16 @@ describe('BackupTab', () => {
     expect(screen.getByRole('button', { name: /Restore from Backup/i })).not.toBeDisabled();
   });
 
+  it('counts collections beyond the common ones (e.g. snapshots) in the summary', async () => {
+    render(<BackupTab />);
+    fireEvent.change(screen.getByTestId('backup-file-input'), {
+      target: {
+        files: [makeFile({ version: '2.0', data: { categories: [], skills: [], snapshots: [{ id: 1 }, { id: 2 }, { id: 3 }] } })],
+      },
+    });
+    await waitFor(() => expect(screen.getByText(/3 snapshots/)).toBeInTheDocument());
+  });
+
   it('rejects a wrong-shape file', async () => {
     render(<BackupTab />);
     fireEvent.change(screen.getByTestId('backup-file-input'), { target: { files: [makeFile({ nope: true })] } });

--- a/client/src/components/settings/__tests__/BackupTab.test.jsx
+++ b/client/src/components/settings/__tests__/BackupTab.test.jsx
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import BackupTab from '../BackupTab';
+
+const mockAuthFetch = vi.fn();
+let mockIsDemo = false;
+
+vi.mock('../../../contexts/AuthContext', () => ({
+  useAuth: () => ({ authFetch: mockAuthFetch }),
+}));
+vi.mock('../../../contexts/ConfigContext', () => ({
+  useConfig: () => ({ isDemo: mockIsDemo }),
+}));
+vi.mock('react-hot-toast', () => ({
+  default: { success: vi.fn(), error: vi.fn() },
+}));
+
+const makeFile = (obj, name = 'skima-backup-2026-06-01.json') =>
+  new File([JSON.stringify(obj)], name, { type: 'application/json' });
+
+const VALID = {
+  exportDate: '2026-06-01T10:00:00.000Z',
+  version: '2.0',
+  data: { categories: [{ id: 1 }], skills: [{ id: 1 }, { id: 2 }], collaborators: [{ id: 1 }] },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockIsDemo = false;
+  document.body.innerHTML = '';
+  // Stub reload so the post-restore window.location.reload() is a no-op in jsdom.
+  Object.defineProperty(window, 'location', {
+    configurable: true,
+    value: { reload: vi.fn(), href: 'http://localhost/' },
+  });
+});
+
+describe('BackupTab', () => {
+  it('renders export and restore sections', () => {
+    render(<BackupTab />);
+    expect(screen.getByRole('heading', { name: /Export Data/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /Restore from Backup/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Download Backup/i })).toBeInTheDocument();
+  });
+
+  it('disables restore in the online demo', () => {
+    mockIsDemo = true;
+    render(<BackupTab />);
+    expect(screen.getByText(/not available in the online demo/i)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Choose File/i })).not.toBeInTheDocument();
+    // export is still available (GET, allowed in demo)
+    expect(screen.getByRole('button', { name: /Download Backup/i })).toBeInTheDocument();
+  });
+
+  it('shows a summary and enables restore for a valid backup file', async () => {
+    render(<BackupTab />);
+    fireEvent.change(screen.getByTestId('backup-file-input'), { target: { files: [makeFile(VALID)] } });
+    await waitFor(() => expect(screen.getByText(/2 skills/)).toBeInTheDocument());
+    expect(screen.getByText(/1 collaborators/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Restore from Backup/i })).not.toBeDisabled();
+  });
+
+  it('rejects a wrong-shape file', async () => {
+    render(<BackupTab />);
+    fireEvent.change(screen.getByTestId('backup-file-input'), { target: { files: [makeFile({ nope: true })] } });
+    await waitFor(() => expect(screen.getByText(/doesn't look like a Skima backup/i)).toBeInTheDocument());
+    expect(screen.getByRole('button', { name: /Restore from Backup/i })).toBeDisabled();
+  });
+
+  it('posts the parsed data to /api/import after confirming', async () => {
+    mockAuthFetch.mockResolvedValue({ ok: true, status: 200, json: async () => ({ success: true }) });
+    render(<BackupTab />);
+
+    fireEvent.change(screen.getByTestId('backup-file-input'), { target: { files: [makeFile(VALID)] } });
+    await waitFor(() => screen.getByText(/2 skills/));
+
+    fireEvent.click(screen.getByRole('button', { name: /Restore from Backup/i }));
+    await waitFor(() => screen.getByText(/Replace All Data\?/i));
+    fireEvent.click(screen.getByRole('button', { name: /Wipe & Restore/i }));
+
+    await waitFor(() => {
+      const importCall = mockAuthFetch.mock.calls.find((c) => String(c[0]).includes('/api/import'));
+      expect(importCall).toBeTruthy();
+      expect(importCall[1].method).toBe('POST');
+      expect(JSON.parse(importCall[1].body).data.skills).toHaveLength(2);
+    });
+  });
+});

--- a/client/src/pages/SettingsPage.jsx
+++ b/client/src/pages/SettingsPage.jsx
@@ -1,13 +1,14 @@
 import { useState, useEffect } from 'react';
 import { createPortal } from 'react-dom';
 import { useSearchParams, useNavigate, useLocation } from 'react-router-dom';
-import { Users, Layers, FolderTree, ClipboardCheck, Briefcase, Target, AlertTriangle, X, Info } from 'lucide-react';
+import { Users, Layers, FolderTree, ClipboardCheck, Briefcase, Target, AlertTriangle, X, Info, Database } from 'lucide-react';
 import CollaboratorsTab from '../components/settings/CollaboratorsTab';
 import SkillsTab from '../components/settings/SkillsTab';
 import CategoriesTab from '../components/settings/CategoriesTab';
 import EvaluationsTab from '../components/settings/EvaluationsTab';
 import RoleProfilesTab from '../components/settings/RoleProfilesTab';
 import DevelopmentTab from '../components/settings/DevelopmentTab';
+import BackupTab from '../components/settings/BackupTab';
 import AboutTab from '../components/settings/AboutTab';
 
 /**
@@ -32,6 +33,7 @@ const TABS = [
   { id: 'colaboradores', label: 'Collaborators', icon: Users },
   { id: 'development', label: 'Development', icon: Target },
   { id: 'evaluaciones', label: 'Evaluations', icon: ClipboardCheck },
+  { id: 'backup', label: 'Backup & Restore', icon: Database },
   { id: 'about', label: 'About', icon: Info },
 ];
 
@@ -158,6 +160,12 @@ export default function SettingsPage() {
         {mountedTabs.includes('evaluaciones') && (
           <div className={activeTab === 'evaluaciones' ? 'flex flex-col flex-1' : 'hidden'}>
             <EvaluationsTab initialContext={navigationContext} isActive={activeTab === 'evaluaciones'} dataVersion={dataVersion} />
+          </div>
+        )}
+
+        {mountedTabs.includes('backup') && (
+          <div className={activeTab === 'backup' ? 'block' : 'hidden'}>
+            <BackupTab />
           </div>
         )}
 

--- a/server/src/__tests__/export-import.test.js
+++ b/server/src/__tests__/export-import.test.js
@@ -28,7 +28,7 @@ describe('Data portability endpoints', () => {
     it('returns the canonical envelope with version and data collections', async () => {
       const res = await request(app).get('/api/export');
       expect(res.status).toBe(200);
-      expect(res.body.version).toBe('1.0');
+      expect(res.body.version).toBe('2.0');
       expect(typeof res.body.exportDate).toBe('string');
       expect(res.body.data).toHaveProperty('categories');
       expect(res.body.data).toHaveProperty('skills');
@@ -92,6 +92,127 @@ describe('Data portability endpoints', () => {
       const a = await prisma.assessment.findFirst();
       expect(a.nivel).toBe(3);
       expect(a.criticidad).toBe('C');
+    });
+  });
+
+  // Full backup covering ALL 20 exportable models — the regression net for the
+  // destructive wipe+restore. Today export dumps only 5 models and import wipes
+  // ~18 but restores 5, so people-dev data is lost; worse, import crashes on any
+  // DB with evaluation sessions (RESTRICT FK, collaborator wiped before session).
+  describe('Full backup (all 20 models)', () => {
+    // leaves -> roots, so a full wipe never hits an FK constraint
+    const wipeOrder = [
+      'developmentAction', 'checkIn', 'reviewSkillRating', 'kPIEntry', 'assessment',
+      'developmentGoal', 'keyResult', 'review', 'kPI', 'checkInNote', 'skill',
+      'evaluationSession', 'developmentPlan', 'objective', 'category', 'collaborator',
+      'snapshot', 'roleProfile', 'timePeriod', 'reviewCycle',
+    ];
+
+    beforeEach(async () => {
+      await prisma.systemConfig.deleteMany();
+      for (const m of wipeOrder) await prisma[m].deleteMany();
+    });
+
+    async function seedAll() {
+      const category = await prisma.category.create({ data: { nombre: 'Backend', abrev: 'BE' } });
+      const skill = await prisma.skill.create({ data: { nombre: 'Node.js', categoriaId: category.id } });
+      const collaborator = await prisma.collaborator.create({
+        data: { nombre: 'Ana', rol: 'Developer', lastEvaluated: new Date('2026-05-01T10:00:00.000Z') },
+      });
+      const snapshot = await prisma.snapshot.create({ data: { nombre: 'Q1 2026' } });
+      const roleProfile = await prisma.roleProfile.create({
+        data: { rol: 'Developer', skills: JSON.stringify({ [skill.id]: 'C' }) },
+      });
+      const session = await prisma.evaluationSession.create({
+        data: { collaboratorId: collaborator.id, collaboratorNombre: 'Ana', collaboratorRol: 'Developer' },
+      });
+      const assessment = await prisma.assessment.create({
+        data: { collaboratorId: collaborator.id, skillId: skill.id, nivel: 3, criticidad: 'C', frecuencia: 'D', evaluationSessionId: session.id },
+      });
+      const plan = await prisma.developmentPlan.create({ data: { collaboratorId: collaborator.id, title: 'Growth Plan' } });
+      const goal = await prisma.developmentGoal.create({ data: { planId: plan.id, title: 'Master Node', skillId: skill.id } });
+      const action = await prisma.developmentAction.create({
+        data: { goalId: goal.id, title: 'Course', status: 'completed', completedAt: new Date('2026-04-15T00:00:00.000Z') },
+      });
+      const period = await prisma.timePeriod.create({ data: { name: 'Q2 2026', startDate: new Date('2026-04-01'), endDate: new Date('2026-06-30') } });
+      const objective = await prisma.objective.create({ data: { title: 'Ship feature', collaboratorId: collaborator.id, timePeriodId: period.id } });
+      const kr = await prisma.keyResult.create({ data: { title: 'Coverage 80%', objectiveId: objective.id, currentValue: 42 } });
+      await prisma.checkIn.create({ data: { keyResultId: kr.id, value: 42 } });
+      const cycle = await prisma.reviewCycle.create({ data: { name: 'H1 Review', periodStart: new Date('2026-01-01'), periodEnd: new Date('2026-06-30'), createdBy: 'Manager' } });
+      const review = await prisma.review.create({ data: { cycleId: cycle.id, collaboratorId: collaborator.id, developmentPlanId: plan.id, overallRating: 4 } });
+      await prisma.reviewSkillRating.create({ data: { reviewId: review.id, skillId: skill.id, rating: 4 } });
+      const kpi = await prisma.kPI.create({ data: { name: 'Velocity', collaboratorId: collaborator.id, objectiveId: objective.id } });
+      await prisma.kPIEntry.create({ data: { kpiId: kpi.id, value: 30, recordedAt: new Date('2026-05-01') } });
+      await prisma.checkInNote.create({ data: { collaboratorId: collaborator.id, content: '1:1 notes', meetingDate: new Date('2026-05-10') } });
+      return { skill, collaborator, session, plan, cycle, review };
+    }
+
+    const ALL_KEYS = [
+      'categories', 'skills', 'collaborators', 'assessments', 'snapshots', 'roleProfiles',
+      'evaluationSessions', 'developmentPlans', 'developmentGoals', 'developmentActions',
+      'timePeriods', 'objectives', 'keyResults', 'checkIns', 'reviewCycles', 'reviews',
+      'reviewSkillRatings', 'kpis', 'kpiEntries', 'checkInNotes',
+    ];
+
+    it('exports every model as a non-empty collection (version 2.0)', async () => {
+      await seedAll();
+      const res = await request(app).get('/api/export');
+      expect(res.status).toBe(200);
+      expect(res.body.version).toBe('2.0');
+      for (const key of ALL_KEYS) {
+        expect(Array.isArray(res.body.data[key])).toBe(true);
+        expect(res.body.data[key].length).toBeGreaterThan(0);
+      }
+    });
+
+    it('round-trips all models through wipe+restore with ids, relations, JSON and dates intact', async () => {
+      const seeded = await seedAll();
+      const exported = await request(app).get('/api/export');
+
+      const res = await request(app).post('/api/import').send({ data: exported.body.data });
+      expect(res.status).toBe(200);
+
+      // UUID PKs + FKs to them preserved (Review chain)
+      const review = await prisma.review.findFirst({ include: { skillRatings: true } });
+      expect(review.id).toBe(seeded.review.id);
+      expect(review.cycleId).toBe(seeded.cycle.id);
+      expect(review.developmentPlanId).toBe(seeded.plan.id);
+      expect(review.skillRatings).toHaveLength(1);
+
+      // Assessment -> EvaluationSession FK preserved (the crash case)
+      const assessment = await prisma.assessment.findFirst();
+      expect(assessment.evaluationSessionId).toBe(seeded.session.id);
+
+      // JSON-as-string intact (not reformatted)
+      const rp = await prisma.roleProfile.findUnique({ where: { rol: 'Developer' } });
+      expect(rp.skills).toBe(JSON.stringify({ [seeded.skill.id]: 'C' }));
+
+      // Denormalized field round-trips as-is
+      const kr = await prisma.keyResult.findFirst();
+      expect(kr.currentValue).toBe(42);
+
+      // Date preserved exactly (no truncation/epoch)
+      const action = await prisma.developmentAction.findFirst();
+      expect(new Date(action.completedAt).toISOString()).toBe('2026-04-15T00:00:00.000Z');
+
+      // Everything present
+      expect(await prisma.objective.count()).toBe(1);
+      expect(await prisma.checkInNote.count()).toBe(1);
+      expect(await prisma.kPIEntry.count()).toBe(1);
+    });
+
+    it('imports a legacy v1.0 backup (only 5 collections) without crashing', async () => {
+      await seedAll();
+      const res = await request(app).post('/api/import').send({
+        data: { categories: [{ id: 100, nombre: 'Legacy', abrev: 'LG' }], skills: [] },
+      });
+      expect(res.status).toBe(200);
+      const cats = await prisma.category.findMany();
+      expect(cats).toHaveLength(1);
+      expect(cats[0].nombre).toBe('Legacy');
+      // absent collections are wiped and not restored
+      expect(await prisma.objective.count()).toBe(0);
+      expect(await prisma.review.count()).toBe(0);
     });
   });
 });

--- a/server/src/__tests__/export-import.test.js
+++ b/server/src/__tests__/export-import.test.js
@@ -201,6 +201,25 @@ describe('Data portability endpoints', () => {
       expect(await prisma.kPIEntry.count()).toBe(1);
     });
 
+    it('rejects a payload whose collections are not arrays and does NOT wipe', async () => {
+      await seedAll();
+      const res = await request(app).post('/api/import').send({ data: { categories: {}, skills: {} } });
+      expect(res.status).toBe(400);
+      // the transaction must not have run — data is intact
+      expect(await prisma.collaborator.count()).toBeGreaterThan(0);
+      expect(await prisma.objective.count()).toBeGreaterThan(0);
+    });
+
+    it('accepts an import payload larger than 1MB (a backup must be restorable)', async () => {
+      const bigCategories = Array.from({ length: 1400 }, (_, i) => ({ id: i + 1, nombre: 'x'.repeat(900), abrev: 'C' }));
+      const size = JSON.stringify({ data: { categories: bigCategories, skills: [] } }).length;
+      expect(size).toBeGreaterThan(1024 * 1024); // > 1MB
+
+      const res = await request(app).post('/api/import').send({ data: { categories: bigCategories, skills: [] } });
+      expect(res.status).toBe(200);
+      expect(await prisma.category.count()).toBe(1400);
+    });
+
     it('imports a legacy v1.0 backup (only 5 collections) without crashing', async () => {
       await seedAll();
       const res = await request(app).post('/api/import').send({

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -58,6 +58,10 @@ export function createApp() {
         : undefined
     )
   );
+  // The import route carries a full-database backup, which easily exceeds the
+  // default 1mb cap — otherwise you could export a backup you can't re-import.
+  // body-parser skips the global 1mb parser below once this one reads the body.
+  app.use('/api/import', express.json({ limit: '25mb' }));
   app.use(express.json({ limit: '1mb' }));
   app.use(cookieParser());
 
@@ -874,8 +878,15 @@ export function createApp() {
     try {
       const { data } = req.body;
 
-      if (!data || !data.categories || !data.skills) {
+      if (!data || !Array.isArray(data.categories) || !Array.isArray(data.skills)) {
         return res.status(400).json({ message: 'Invalid data format' });
+      }
+      // A malformed collection must never trigger the destructive wipe: reject
+      // before touching the DB if any provided collection isn't an array.
+      for (const { key } of BACKUP_MODELS) {
+        if (data[key] !== undefined && !Array.isArray(data[key])) {
+          return res.status(400).json({ message: `Invalid data format: ${key} must be an array` });
+        }
       }
 
       await prisma.$transaction(async (tx) => {

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -821,25 +821,44 @@ export function createApp() {
   // DATA PORTABILITY ROUTES
   // ============================================================
 
-  // GET /api/export - Full JSON dump
+  // All backup-able models in restore order (parents -> children). Export dumps
+  // each; import restores in this order and wipes in reverse. SystemConfig is
+  // intentionally excluded — it holds the admin password hash and install-local
+  // config, which must never travel in a portable backup.
+  const BACKUP_MODELS = [
+    { key: 'categories', model: 'category' },
+    { key: 'collaborators', model: 'collaborator' },
+    { key: 'snapshots', model: 'snapshot' },
+    { key: 'roleProfiles', model: 'roleProfile' },
+    { key: 'timePeriods', model: 'timePeriod' },
+    { key: 'reviewCycles', model: 'reviewCycle' },
+    { key: 'skills', model: 'skill' },
+    { key: 'evaluationSessions', model: 'evaluationSession' },
+    { key: 'developmentPlans', model: 'developmentPlan' },
+    { key: 'objectives', model: 'objective' },
+    { key: 'checkInNotes', model: 'checkInNote' },
+    { key: 'assessments', model: 'assessment' },
+    { key: 'developmentGoals', model: 'developmentGoal' },
+    { key: 'keyResults', model: 'keyResult' },
+    { key: 'reviews', model: 'review' },
+    { key: 'kpis', model: 'kPI' },
+    { key: 'developmentActions', model: 'developmentAction' },
+    { key: 'checkIns', model: 'checkIn' },
+    { key: 'reviewSkillRatings', model: 'reviewSkillRating' },
+    { key: 'kpiEntries', model: 'kPIEntry' },
+  ];
+
+  // GET /api/export - Full JSON dump of all data (excludes SystemConfig)
   app.get('/api/export', authMiddleware, async (req, res) => {
     try {
-      const categories = await prisma.category.findMany();
-      const skills = await prisma.skill.findMany();
-      const collaborators = await prisma.collaborator.findMany();
-      const assessments = await prisma.assessment.findMany();
-      const snapshots = await prisma.snapshot.findMany();
-
+      const data = {};
+      for (const { key, model } of BACKUP_MODELS) {
+        data[key] = await prisma[model].findMany();
+      }
       res.json({
         exportDate: new Date().toISOString(),
-        version: '1.0',
-        data: {
-          categories,
-          skills,
-          collaborators,
-          assessments,
-          snapshots
-        }
+        version: '2.0',
+        data,
       });
     } catch (error) {
       console.error('[API] GET /api/export failed:', error);
@@ -847,7 +866,10 @@ export function createApp() {
     }
   });
 
-  // POST /api/import - Wipe and replace (Protected)
+  // POST /api/import - Wipe and replace, atomically (Protected).
+  // Restores every collection present in the payload. A legacy v1.0 backup (only
+  // categories/skills/collaborators/assessments/snapshots) imports cleanly — the
+  // newer collections are simply absent and skipped.
   app.post('/api/import', authMiddleware, async (req, res) => {
     try {
       const { data } = req.body;
@@ -856,42 +878,21 @@ export function createApp() {
         return res.status(400).json({ message: 'Invalid data format' });
       }
 
-      // Wipe existing data (order matters due to foreign keys)
-      await prisma.developmentAction.deleteMany();
-      await prisma.developmentGoal.deleteMany();
-      await prisma.developmentPlan.deleteMany();
-      await prisma.checkIn.deleteMany();
-      await prisma.keyResult.deleteMany();
-      await prisma.objective.deleteMany();
-      await prisma.timePeriod.deleteMany();
-      await prisma.reviewSkillRating.deleteMany();
-      await prisma.review.deleteMany();
-      await prisma.reviewCycle.deleteMany();
-      await prisma.kPIEntry.deleteMany();
-      await prisma.kPI.deleteMany();
-      await prisma.checkInNote.deleteMany();
-      await prisma.assessment.deleteMany();
-      await prisma.snapshot.deleteMany();
-      await prisma.collaborator.deleteMany();
-      await prisma.skill.deleteMany();
-      await prisma.category.deleteMany();
-
-      // Import new data
-      if (data.categories.length > 0) {
-        await prisma.category.createMany({ data: data.categories });
-      }
-      if (data.skills.length > 0) {
-        await prisma.skill.createMany({ data: data.skills });
-      }
-      if (data.collaborators?.length > 0) {
-        await prisma.collaborator.createMany({ data: data.collaborators });
-      }
-      if (data.snapshots?.length > 0) {
-        await prisma.snapshot.createMany({ data: data.snapshots });
-      }
-      if (data.assessments?.length > 0) {
-        await prisma.assessment.createMany({ data: data.assessments });
-      }
+      await prisma.$transaction(async (tx) => {
+        // Wipe leaves -> roots so foreign keys never block a delete.
+        for (const { model } of [...BACKUP_MODELS].reverse()) {
+          await tx[model].deleteMany();
+        }
+        // Restore roots -> leaves. Rows carry their original ids so relations
+        // (including string-UUID PKs and the FKs that point at them) survive.
+        // Prisma coerces ISO date strings on createMany; nulls stay null.
+        for (const { key, model } of BACKUP_MODELS) {
+          const rows = data[key];
+          if (Array.isArray(rows) && rows.length > 0) {
+            await tx[model].createMany({ data: rows });
+          }
+        }
+      }, { timeout: 30000 });
 
       res.json({ success: true, message: 'Data imported successfully' });
     } catch (error) {


### PR DESCRIPTION
Closes #71. Makes the export/import a real, safe, complete backup — the data-loss risk that motivated #71.

## The problem
`GET /api/export` dumped only 5 of 21 models; `POST /api/import` wiped ~18 tables but restored 5 — so a "restore" **destroyed** all IDPs, OKRs, reviews, KPIs, evaluation sessions and role profiles. Worse, the wipe omitted `evaluationSession`/`roleProfile`, so importing onto any DB with evaluation sessions **crashed** on the collaborator RESTRICT FK.

## Backend
- Single ordered `BACKUP_MODELS` list (SystemConfig excluded — it holds the admin password hash). Export dumps all 20 data models, `version: '2.0'`.
- Import runs in a `$transaction`: wipes leaves→roots, restores roots→leaves, preserving original ids (incl. string-UUID review PKs) so relations survive. FK-safe order verified against the schema.
- Backward-compatible: legacy v1.0 backups (5 collections) still import.
- Import gets a 25mb body limit (a real backup exceeds the global 1mb) and array validation so a malformed payload can't trigger a silent wipe.

## Frontend
- New Settings **Backup & Restore** tab: Download Backup (→ `skima-backup-YYYY-MM-DD.json`) and Restore (client-side parse + validation, record-count summary of all 20 collections, destructive `ConfirmModal` "Wipe & Restore", reload on success). Disabled in the online demo; 403/413 handled; invalid/legacy files handled.

## Validation
- Server 214→219, client 914→920. Full 20-model round-trip test (ids/relations/JSON/dates intact), legacy-compat, >1mb, and non-array-no-wipe tests. Lint clean.
- Reviewed by UX, code-review, and QA; all findings addressed.

Follow-up (out of scope): auto-backup (scheduled), per the roadmap.